### PR TITLE
feat: add kids banking light and dark color palettes

### DIFF
--- a/lib/common/styling/palettes/kids/dark.dart
+++ b/lib/common/styling/palettes/kids/dark.dart
@@ -1,0 +1,114 @@
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+final class KidsDarkPalette extends GtPalette {
+  KidsDarkPalette()
+      : super(
+          primary: GtPaletteBrandColors(
+            darker: GtColors.purple900.value,
+            dark: GtColors.purple400.value,
+            base: GtColors.purple500.value,
+            alpha16: GtColors.purpleAlpha16.value,
+            alpha10: GtColors.purpleAlpha10.value,
+          ),
+          sterling: GtPaletteBrandColors(
+            darker: GtColors.purple900.value,
+            dark: GtColors.purple400.value,
+            base: GtColors.purple500.value,
+            alpha16: GtColors.purpleAlpha16.value,
+            alpha10: GtColors.purpleAlpha10.value,
+          ),
+          staticColors: GtPaletteStaticColors(
+            black: GtColors.neutral950.value,
+            white: GtColors.neutral0.value,
+            shadow: GtColors.neutralGray700.dark,
+          ),
+          bg: GtPaletteBgColors(
+            strong: GtColors.neutral950.dark,
+            surface: GtColors.neutral800.dark,
+            sub: GtColors.neutral300.dark,
+            soft: GtColors.neutral200.dark,
+            weak: GtColors.neutral50.dark,
+            white: GtColors.neutral0.dark,
+          ),
+          text: GtPaletteContentColors(
+            strong: GtColors.neutral950.dark,
+            sub: GtColors.neutral600.dark,
+            soft: GtColors.neutral400.dark,
+            disabled: GtColors.neutral300.dark,
+            white: GtColors.neutral0.dark,
+          ),
+          icon: GtPaletteContentColors(
+            strong: GtColors.neutral950.dark,
+            sub: GtColors.neutral600.dark,
+            soft: GtColors.neutral400.dark,
+            disabled: GtColors.neutral300.dark,
+            white: GtColors.neutral0.dark,
+          ),
+          stroke: GtPaletteStrokeColors(
+            strong: GtColors.neutral950.dark,
+            sub: GtColors.neutral300.dark,
+            soft: GtColors.neutral200.dark,
+            white: GtColors.neutral0.dark,
+          ),
+          faded: GtPaletteStateColors(
+            dark: GtColors.neutral300.value,
+            base: GtColors.neutral500.value,
+            light: GtColors.neutralAlpha24.value,
+            lighter: GtColors.neutralAlpha16.value,
+          ),
+          information: GtPaletteStateColors(
+            dark: GtColors.blue400.value,
+            base: GtColors.blue500.value,
+            light: GtColors.blueAlpha24.value,
+            lighter: GtColors.blueAlpha16.value,
+          ),
+          warning: GtPaletteStateColors(
+            dark: GtColors.orange400.value,
+            base: GtColors.orange600.value,
+            light: GtColors.orangeAlpha24.value,
+            lighter: GtColors.orangeAlpha16.value,
+          ),
+          error: GtPaletteStateColors(
+            dark: GtColors.red400.value,
+            base: GtColors.red600.value,
+            light: GtColors.redAlpha24.value,
+            lighter: GtColors.redAlpha16.value,
+          ),
+          success: GtPaletteStateColors(
+            dark: GtColors.green400.value,
+            base: GtColors.green600.value,
+            light: GtColors.greenAlpha24.value,
+            lighter: GtColors.greenAlpha16.value,
+          ),
+          away: GtPaletteStateColors(
+            dark: GtColors.yellow400.value,
+            base: GtColors.yellow600.value,
+            light: GtColors.yellowAlpha24.value,
+            lighter: GtColors.yellowAlpha16.value,
+          ),
+          feature: GtPaletteStateColors(
+            dark: GtColors.purple400.value,
+            base: GtColors.purple500.value,
+            light: GtColors.purpleAlpha24.value,
+            lighter: GtColors.purpleAlpha16.value,
+          ),
+          verified: GtPaletteStateColors(
+            dark: GtColors.sky400.value,
+            base: GtColors.sky600.value,
+            light: GtColors.skyAlpha24.value,
+            lighter: GtColors.skyAlpha16.value,
+          ),
+          highlighted: GtPaletteStateColors(
+            dark: GtColors.pink400.value,
+            base: GtColors.pink600.value,
+            light: GtColors.pinkAlpha24.value,
+            lighter: GtColors.pinkAlpha16.value,
+          ),
+          stable: GtPaletteStateColors(
+            dark: GtColors.teal400.value,
+            base: GtColors.teal600.value,
+            light: GtColors.tealAlpha24.value,
+            lighter: GtColors.tealAlpha16.value,
+          ),
+        );
+}

--- a/lib/common/styling/palettes/kids/kids.dart
+++ b/lib/common/styling/palettes/kids/kids.dart
@@ -1,0 +1,2 @@
+export 'dark.dart';
+export 'light.dart';

--- a/lib/common/styling/palettes/kids/light.dart
+++ b/lib/common/styling/palettes/kids/light.dart
@@ -1,0 +1,114 @@
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+final class KidsLightPalette extends GtPalette {
+  KidsLightPalette()
+      : super(
+          primary: GtPaletteBrandColors(
+            darker: GtColors.purple900.value,
+            dark: GtColors.purple400.value,
+            base: GtColors.purple500.value,
+            alpha16: GtColors.purpleAlpha16.value,
+            alpha10: GtColors.purpleAlpha10.value,
+          ),
+          sterling: GtPaletteBrandColors(
+            darker: GtColors.purple900.value,
+            dark: GtColors.purple400.value,
+            base: GtColors.purple500.value,
+            alpha16: GtColors.purpleAlpha16.value,
+            alpha10: GtColors.purpleAlpha10.value,
+          ),
+          staticColors: GtPaletteStaticColors(
+            black: GtColors.neutral950.value,
+            white: GtColors.neutral0.value,
+            shadow: GtColors.neutralGray700.value,
+          ),
+          bg: GtPaletteBgColors(
+            strong: GtColors.neutral950.value,
+            surface: GtColors.neutral800.value,
+            sub: GtColors.neutral300.value,
+            soft: GtColors.neutral200.value,
+            weak: GtColors.neutral50.value,
+            white: GtColors.neutral0.value,
+          ),
+          text: GtPaletteContentColors(
+            strong: GtColors.neutral950.value,
+            sub: GtColors.neutral600.value,
+            soft: GtColors.neutral400.value,
+            disabled: GtColors.neutral300.value,
+            white: GtColors.neutral0.value,
+          ),
+          icon: GtPaletteContentColors(
+            strong: GtColors.neutral950.value,
+            sub: GtColors.neutral600.value,
+            soft: GtColors.neutral400.value,
+            disabled: GtColors.neutral300.value,
+            white: GtColors.neutral0.value,
+          ),
+          stroke: GtPaletteStrokeColors(
+            strong: GtColors.neutral950.value,
+            sub: GtColors.neutral300.value,
+            soft: GtColors.neutral200.value,
+            white: GtColors.neutral0.value,
+          ),
+          faded: GtPaletteStateColors(
+            dark: GtColors.neutral800.value,
+            base: GtColors.neutral500.value,
+            light: GtColors.neutral200.value,
+            lighter: GtColors.neutral100.value,
+          ),
+          information: GtPaletteStateColors(
+            dark: GtColors.blue950.value,
+            base: GtColors.blue500.value,
+            light: GtColors.blue200.value,
+            lighter: GtColors.blue50.value,
+          ),
+          warning: GtPaletteStateColors(
+            dark: GtColors.orange950.value,
+            base: GtColors.orange500.value,
+            light: GtColors.orange200.value,
+            lighter: GtColors.orange50.value,
+          ),
+          error: GtPaletteStateColors(
+            dark: GtColors.red950.value,
+            base: GtColors.red500.value,
+            light: GtColors.red200.value,
+            lighter: GtColors.red50.value,
+          ),
+          success: GtPaletteStateColors(
+            dark: GtColors.green950.value,
+            base: GtColors.green500.value,
+            light: GtColors.green200.value,
+            lighter: GtColors.green50.value,
+          ),
+          away: GtPaletteStateColors(
+            dark: GtColors.yellow950.value,
+            base: GtColors.yellow500.value,
+            light: GtColors.yellow200.value,
+            lighter: GtColors.yellow50.value,
+          ),
+          feature: GtPaletteStateColors(
+            dark: GtColors.purple950.value,
+            base: GtColors.purple500.value,
+            light: GtColors.purple200.value,
+            lighter: GtColors.purple50.value,
+          ),
+          verified: GtPaletteStateColors(
+            dark: GtColors.sky950.value,
+            base: GtColors.sky500.value,
+            light: GtColors.sky200.value,
+            lighter: GtColors.sky50.value,
+          ),
+          highlighted: GtPaletteStateColors(
+            dark: GtColors.pink950.value,
+            base: GtColors.pink500.value,
+            light: GtColors.pink200.value,
+            lighter: GtColors.pink50.value,
+          ),
+          stable: GtPaletteStateColors(
+            dark: GtColors.teal950.value,
+            base: GtColors.teal500.value,
+            light: GtColors.teal200.value,
+            lighter: GtColors.teal50.value,
+          ),
+        );
+}

--- a/lib/common/styling/palettes/palettes.dart
+++ b/lib/common/styling/palettes/palettes.dart
@@ -1,2 +1,3 @@
 export 'gt_palette.dart';
 export 'personal/personal.dart';
+export 'kids/kids.dart';


### PR DESCRIPTION
## Description

- Add KidsLightPalette and KidsDarkPalette extending GtPalette
- Export kids barrel from palettes.dart

## ✨ Type of Change

- [ ] ✨ New Feature
- [ ] 🐛 Bug Fix
- [x] ⚡ Performance Improvement
- [ ] 🎨 UI/UX Change (Screenshots Required)
- [ ] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)
- N/A

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x]  `flutter test` passes (all tests green).
- [x]  `dart format` applied.
- [ ] No unused code.
- [ ] Verified UI on small/large screens.