### PR TITLE
refactor: update GtLimitEditListTile with info interaction, switch Gt…

### DIFF
--- a/gallery/lib/molecules/tiles/gt_list_tile.dart
+++ b/gallery/lib/molecules/tiles/gt_list_tile.dart
@@ -422,14 +422,12 @@ Widget gtListTileAllUseCase(BuildContext context) {
             value: limitAirtime,
             max: 80000,
             onEdit: () {},
+            onTapInfo: () {
+              context.showToast("You clicked info");
+            },
           ),
           const GtGap.yLg(),
-          GtLimitEditListTile(
-            "Bill Payments",
-            value: limitBills,
-            max: 80000,
-            onEdit: () {},
-          ),
+          GtLimitEditListTile("Bill Payments", value: limitBills, max: 80000),
         ],
       ),
     ),

--- a/lib/widgets/molecules/inputs/gt_dob_field.dart
+++ b/lib/widgets/molecules/inputs/gt_dob_field.dart
@@ -136,12 +136,18 @@ class _GtDobFieldState extends State<GtDobField> with GtBottomSheetMixin {
           ),
           Expanded(
             flex: 2,
-            child: GtAutocompleteField<int>(
+            child: GtAutocompleteField<int>.builder(
               key: const ValueKey("gt_dob_field_month"),
               label: "month".ctr(),
               textCapitalization: .words,
               autofillHints: const [AutofillHints.birthdayMonth],
-              suggestions: _dobController.monthSuggestions,
+              builder: (query) {
+                return _dobController.monthSuggestions.whereList((it) {
+                  final digit = int.tryParse(query) ?? 0;
+                  final monthName = it.value.asMonthName.toLowerCase();
+                  return monthName.includes(query) || it.value == digit;
+                });
+              },
               controller: _monthCtrl,
               onChange: (value) {
                 final selectedDay = _dobController.day ?? 1;

--- a/lib/widgets/molecules/tiles/gt_limit_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_limit_tiles.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
@@ -117,17 +116,20 @@ class GtLimitEditListTile extends GtStatelessWidget {
                       text: category,
                       children: [
                         TextSpan(text: " "),
-                        WidgetSpan(
-                          child: GtIcon(GtIcons.info, size: 18, variant: .soft),
-                          alignment: .middle,
-                        ),
+                        if (onTapInfo != null)
+                          WidgetSpan(
+                            child: GtInkWell(
+                              onTap: onTapInfo,
+                              child: GtIcon(
+                                GtIcons.info,
+                                size: 18,
+                                variant: .soft,
+                              ),
+                            ),
+                            alignment: .middle,
+                          ),
                       ],
-                      recognizer: TapGestureRecognizer()
-                        ..onTap = () {
-                          if (onTapInfo == null) return;
-                          HapticFeedback.lightImpact();
-                          onTapInfo?.call();
-                        },
+                      recognizer: TapGestureRecognizer()..onTap = onTapInfo,
                     ),
                     style: context.textStyles.subHeadM(),
                   ),
@@ -152,12 +154,11 @@ class GtLimitEditListTile extends GtStatelessWidget {
               ),
           ],
         ),
-        const GtGap.ySm(),
         GtAnimatedProgress(
           value: _fraction,
+          key: ValueKey(_fraction),
           valueColor: context.palette.primary.base,
         ),
-        const GtGap.ySm(),
         Align(
           alignment: Alignment.centerRight,
           child: GtText(


### PR DESCRIPTION
## Description

- **Purpose:** Refactor & UI/UX Enhancement
- **Issue Link:** #108
- **Summary:**
  - **GtLimitEditListTile Refactoring:**
    - Wrapped the info icon with `GtInkWell` to make it interactive and only display if `onTapInfo` is provided.
    - Simplified gesture handling by passing `onTapInfo` directly to the `TapGestureRecognizer` and removing redundant haptics.
    - Added `ValueKey(_fraction)` to `GtAnimatedProgress` to ensure correct animation and rendering when the value changes.
    - Cleaned up unnecessary imports (`flutter/services.dart`) and extra spacing vertical gaps (`GtGap.ySm()`).
  - **GtDobField Month Auto-Complete:**
    - Migrated the month autocomplete input field to `GtAutocompleteField<int>.builder` to dynamically filter and suggest months based on matching names (e.g. "January") or numbers (e.g. "1").
  - **Gallery Updates:**
    - Updated `gtListTileAllUseCase` in [gt_list_tile.dart](file:///Users/macpro/Documents/Code/Dart/Flutter/Sterling/gt_mobile_ui/gallery/lib/molecules/tiles/gt_list_tile.dart) to showcase the new `onTapInfo` interaction on `GtLimitEditListTile` and cleanup layout examples.

## ✨ Type of Change

- [ ] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)

<img width="450" height="955" alt="Screenshot 2026-05-25 at 13 59 33" src="https://github.com/user-attachments/assets/d78af427-cb7f-4f98-be04-81998ed8ad87" />
<img width="450" height="955" alt="Screenshot 2026-05-25 at 13 59 59" src="https://github.com/user-attachments/assets/2b08e0a1-16e0-4c65-ab7c-03520c573283" />


## 🧪 How Has This Been Tested?

- [ ] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:*
    1. Opened the UI Gallery and navigated to List Tiles.
    2. Clicked on the Info icon of `GtLimitEditListTile` to verify that the `onTapInfo` callback fires (shows toast).
    3. Opened the DOB field component and verified month suggestion filtering matches both name query and number query correctly.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [ ]  `flutter test` passes (all tests green). *(Note: `test/gt_mobile_ui_test.dart` is currently empty)*
- [x]  `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.