### PR TITLE
[FEAT]: Makes GtTipCard receive rich text

### DIFF
--- a/gallery/lib/organisms/cards/gt_card.dart
+++ b/gallery/lib/organisms/cards/gt_card.dart
@@ -214,7 +214,7 @@ Widget buildGtCardUseCase(BuildContext context) {
               GtReminderBanner(
                 title: "UPGRADE FOLA'S ACCOUNT",
                 subtitle:
-                    "Fola is ready to move to a full OneBank account with full access to their money.",
+                    "You're 18 now! Time to upgrade your account and unlock more features built for you.",
                 icon: GtSvg(GtVectorIllustrations.referral),
                 onClose: () {},
                 variant: alertVariant,

--- a/gallery/lib/templates/slides/gt_slides.dart
+++ b/gallery/lib/templates/slides/gt_slides.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
@@ -42,134 +40,70 @@ List<GtSlideData> getPersonalAppSlides(BuildContext context) {
 
 final _lessonsController = GtLessonslideController(
   slides: [
-    GtLessonSlideData.withHeader(
+    GtLessonSlideData.withImage(
       color: GtColors.pink100.value,
       title: "LESSON 1",
-      data: GtLessonSlideHeader(
+      data: AppImageData(GtVectorIllustrations.vault),
+      alignment: .center,
+      header: GtLessonSlideHeader(
         title: "WHAT IS SAVING",
         subTitle:
             "Saving means keeping some of your money to use later instead of spending it all at once.",
-        embedSubtitleInCard: true,
-        offset: Offset(0, 350),
       ),
-      backgroundImages: [
-        GtLessonSlideImage(
-          image: AppImageData.asset(GtVectorIllustrations.coins),
-          offset: Offset(0, 100),
-          alignment: .topRight,
-          fit: .cover,
-          height: 160,
-        ),
-        GtLessonSlideImage(
-          image: AppImageData.asset(GtVectorIllustrations.cash),
-          offset: Offset(-80, -100),
-          alignment: .bottomLeft,
-          fit: .cover,
-          height: 240,
-        ),
-      ],
     ),
-    GtLessonSlideData.withHeader(
+    GtLessonSlideData.withImage(
       color: GtColors.purple100.value,
       title: "LESSON 2",
-      data: GtLessonSlideHeader(
+      data: AppImageData(GtVectorIllustrations.cash),
+      alignment: .center,
+      header: GtLessonSlideHeader(
         title: "why saving matters?".upper,
         subTitle:
             "Saving helps you plan ahead, buy things you really want, and handle unexpected needs.",
-        embedSubtitleInCard: true,
-        offset: Offset(0, 150),
       ),
-      backgroundImages: [
-        GtLessonSlideImage(
-          image: AppImageData.asset(GtVectorIllustrations.vault),
-          offset: Offset(80, 0),
-          alignment: .centerRight,
-          fit: .cover,
-          height: 240,
-        ),
-        GtLessonSlideImage(
-          image: AppImageData.asset(GtVectorIllustrations.announcement),
-          offset: Offset(-80, 50),
-          rotation: pi / 250,
-          alignment: .bottomLeft,
-          fit: .cover,
-          height: 240,
-        ),
-      ],
     ),
-    GtLessonSlideData.withHeader(
+    GtLessonSlideData.withImage(
       color: GtColors.yellow100.value,
       title: "LESSON 3",
-      data: GtLessonSlideHeader(
+      data: AppImageData(GtVectorIllustrations.coins),
+      alignment: .center,
+      header: GtLessonSlideHeader(
         title: "WHAT IS SAVING",
         subTitle:
             "Saving means keeping some of your money to use later instead of spending it all at once.",
-        embedSubtitleInCard: true,
-        offset: Offset(0, 300),
       ),
-      backgroundImages: [
-        GtLessonSlideImage(
-          image: AppImageData.asset(GtVectorIllustrations.coins),
-          offset: Offset(0, 50),
-          alignment: .topLeft,
-          fit: .cover,
-          height: 160,
-        ),
-        GtLessonSlideImage(
-          image: AppImageData.asset(GtVectorIllustrations.cash),
-          offset: .zero,
-          alignment: .bottomCenter,
-          fit: .cover,
-          height: 320,
-        ),
-      ],
     ),
     GtLessonSlideData.withImage(
-      color: GtColors.neutral50.value,
-      gradient: LinearGradient(
-        begin: .centerLeft,
-        end: .centerRight,
-        colors: [Color(0x1AB8CDD9), GtColors.neutral50.value],
-      ),
       alignment: .bottomRight,
       title: "LESSON 4",
       data: AppImageData(
         "https://storage.googleapis.com/dump-storage-jesse/enter_account_number.png",
       ),
+      imageSize: null,
       header: GtLessonSlideHeader(
         title: "enter account number".upper,
         subTitle: "Enter account number in the field below or select contact",
       ),
     ),
     GtLessonSlideData.withImage(
-      color: GtColors.neutral50.value,
-      gradient: LinearGradient(
-        begin: .centerLeft,
-        end: .centerRight,
-        colors: [Color(0x1AB8CDD9), GtColors.neutral50.value],
-      ),
       alignment: .bottomRight,
       title: "LESSON 5",
       data: AppImageData(
         "https://storage.googleapis.com/dump-storage-jesse/select_bank.png",
       ),
+      imageSize: null,
       header: GtLessonSlideHeader(
         title: "select bank".upper,
         subTitle: "Select beneficiary’s bank from suggested or all banks list",
       ),
     ),
     GtLessonSlideData.withImage(
-      color: GtColors.neutral50.value,
-      gradient: LinearGradient(
-        begin: .centerLeft,
-        end: .centerRight,
-        colors: [Color(0x1AB8CDD9), GtColors.neutral50.value],
-      ),
       alignment: .bottomRight,
       title: "LESSON 6",
       data: AppImageData(
         "https://storage.googleapis.com/dump-storage-jesse/enter_amount.png",
       ),
+      imageSize: null,
       header: GtLessonSlideHeader(
         title: "enter amount".upper,
         subTitle: "Enter the amount you want to send to beneficary",
@@ -177,6 +111,10 @@ final _lessonsController = GtLessonslideController(
     ),
     GtLessonSlideData.withAV(
       title: "LESSON 7",
+      header: GtLessonSlideHeader(
+        title: "Zero Transfer Charges".upper,
+        subTitle: "Learn how to use our Design System",
+      ),
       data: AppAvData(document: "https://www.youtube.com/shorts/MXAn49kEcj4"),
     ),
     GtLessonSlideData.withAV(

--- a/lib/common/data/gt_slide_data.dart
+++ b/lib/common/data/gt_slide_data.dart
@@ -87,37 +87,11 @@ class GtLessonSlideHeader extends AppEquatable {
   /// The secondary subtitle text of the header.
   final String subTitle;
 
-  /// The text style for the [title].
-  final TextStyle? titleStyle;
-
-  /// The text style for the [subTitle].
-  final TextStyle? subtitleStyle;
-
-  /// Whether the subtitle should be visually embedded within a card-like container.
-  final bool embedSubtitleInCard;
-
-  /// The positional offset of the header on the slide.
-  final Offset offset;
-
   /// Creates a [GtLessonSlideHeader] instance.
-  const GtLessonSlideHeader({
-    required this.title,
-    required this.subTitle,
-    this.titleStyle,
-    this.subtitleStyle,
-    this.embedSubtitleInCard = false,
-    this.offset = Offset.zero,
-  });
+  const GtLessonSlideHeader({required this.title, required this.subTitle});
 
   @override
-  List<Object?> get props => [
-    title,
-    subTitle,
-    titleStyle,
-    subtitleStyle,
-    embedSubtitleInCard,
-    offset,
-  ];
+  List<Object?> get props => [title, subTitle];
 }
 
 /// Defines a background image to be rendered behind the slide content.
@@ -175,7 +149,7 @@ class GtLessonSlideImage extends AppEquatable {
 /// of a single lesson slide (e.g., in a story-style format).
 class GtLessonSlideData extends AppEquatable {
   /// The header information displayed over the slide content.
-  final GtLessonSlideHeader? header;
+  final GtLessonSlideHeader header;
 
   /// The main title of the slide.
   final String title;
@@ -186,17 +160,11 @@ class GtLessonSlideData extends AppEquatable {
   /// The background color of the slide.
   final Color? color;
 
-  /// The color of the text on the slide.
-  final Color? textColor;
-
   /// A gradient applied to the background of the slide.
   final Gradient? gradient;
 
   /// The media content (image, video, or audio) for the slide.
   final AppMediaData? media;
-
-  /// A list of background images to layer behind the slide content.
-  final List<GtLessonSlideImage>? backgroundImages;
 
   /// The explicit type of the slide.
   final GtLessonSlideType slideType;
@@ -204,32 +172,46 @@ class GtLessonSlideData extends AppEquatable {
   /// Optional alignment for the media content.
   final Alignment? imageAlignment;
 
+  /// Optional alignment for the media content.
+  final double? imageSize;
+
+  /// Creates a [GtLessonSlideData] instance.
+  const GtLessonSlideData({
+    required this.title,
+    this.color,
+    required this.header,
+    this.gradient,
+    required this.slideType,
+    this.media,
+    this.imageAlignment,
+    this.text,
+    this.imageSize,
+  });
+
   /// Creates a slide that primarily displays an image.
   const GtLessonSlideData.withImage({
     required AppImageData data,
     required Alignment alignment,
     required this.title,
     this.color,
-    this.header,
+    required this.header,
     this.gradient,
+    this.imageSize = 240,
   }) : slideType = .image,
        imageAlignment = alignment,
        media = data,
-       backgroundImages = null,
-       text = null,
-       textColor = null;
+       text = null;
 
   /// Creates a slide that primarily displays text.
   const GtLessonSlideData.withText({
-    this.header,
+    required this.header,
     required String data,
     required this.title,
-    required this.textColor,
     this.color,
     this.gradient,
-    this.backgroundImages,
   }) : slideType = .text,
        media = null,
+       imageSize = null,
        imageAlignment = null,
        text = data;
 
@@ -239,27 +221,25 @@ class GtLessonSlideData extends AppEquatable {
     required this.title,
     this.color,
     this.gradient,
-    this.backgroundImages,
   }) : slideType = .text,
        media = null,
        header = data,
+       imageSize = null,
        imageAlignment = null,
-       text = null,
-       textColor = null;
+       text = null;
 
   /// Creates a slide that displays audio or video media.
   const GtLessonSlideData.withAV({
     required AppAvData data,
     required this.title,
-    this.header,
+    required this.header,
     this.color,
     this.gradient,
   }) : media = data,
        slideType = .audioVisual,
-       backgroundImages = null,
        imageAlignment = null,
-       text = null,
-       textColor = null;
+       imageSize = null,
+       text = null;
 
   /// Calculates the display duration of the slide based on its content.
   ///
@@ -297,8 +277,8 @@ class GtLessonSlideData extends AppEquatable {
   /// Assumes an average reading speed of 200 words per minute.
   Duration get _getTextDuration {
     try {
-      final title = header?.title ?? "";
-      final sub = header?.subTitle ?? "";
+      final title = header.title;
+      final sub = header.subTitle;
       final content = "${text ?? ''} $title $sub";
 
       if (!content.hasValue) return 0.seconds;
@@ -318,10 +298,8 @@ class GtLessonSlideData extends AppEquatable {
     title,
     text,
     color,
-    textColor,
     gradient,
     media,
-    backgroundImages,
     slideType,
     imageAlignment,
   ];
@@ -534,7 +512,7 @@ final class GtLessonslideController extends ChangeNotifier {
   @override
   void dispose() {
     reset(notify: false);
-    _mediaPlayer?.dispose();
+
     super.dispose();
   }
 }

--- a/lib/common/styling/gt_colors.dart
+++ b/lib/common/styling/gt_colors.dart
@@ -255,6 +255,7 @@ enum GtColors {
   maroonAlpha16(ColorSet(0x29CB0828)),
   maroonAlpha10(ColorSet(0x1ACB0828)),
 
+  skyAlpha5(ColorSet(0x1AB8CDD9)),
   darkGreen(ColorSet(0xFF004045)),
   lemon(ColorSet(0xFF26E36B));
 

--- a/lib/common/styling/gt_gradients.dart
+++ b/lib/common/styling/gt_gradients.dart
@@ -68,4 +68,16 @@ class GtGradients {
       end: Alignment.bottomRight,
     );
   }
+
+  /// Creates a two-tone linear gradient.
+  ///
+  /// Transitions from the provided [light] color at the top-left to the [dark] color at the bottom-right.
+  Gradient slideGradient() {
+    return LinearGradient(
+      begin: .bottomLeft,
+      end: .topRight,
+      colors: [context.palette.bg.sky, context.palette.bg.weak],
+      stops: [.8, 1],
+    );
+  }
 }

--- a/lib/common/styling/palettes/flex/dark.dart
+++ b/lib/common/styling/palettes/flex/dark.dart
@@ -30,6 +30,7 @@ final class FlexDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.dark,
@@ -41,6 +42,7 @@ final class FlexDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.dark,

--- a/lib/common/styling/palettes/flex/light.dart
+++ b/lib/common/styling/palettes/flex/light.dart
@@ -30,6 +30,7 @@ final class FlexLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.value,
@@ -41,6 +42,7 @@ final class FlexLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.value,

--- a/lib/common/styling/palettes/gotech/dark.dart
+++ b/lib/common/styling/palettes/gotech/dark.dart
@@ -30,6 +30,7 @@ final class GotechDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.dark,
@@ -41,6 +42,7 @@ final class GotechDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.dark,

--- a/lib/common/styling/palettes/gotech/light.dart
+++ b/lib/common/styling/palettes/gotech/light.dart
@@ -30,6 +30,7 @@ final class GotechLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.value,
@@ -41,6 +42,7 @@ final class GotechLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.value,

--- a/lib/common/styling/palettes/gt_palette.dart
+++ b/lib/common/styling/palettes/gt_palette.dart
@@ -148,6 +148,7 @@ class GtPaletteBgColors {
   final Color white;
   final Color warm;
   final Color neutralWarm50;
+  final Color sky;
 
   const GtPaletteBgColors({
     required this.strong,
@@ -159,6 +160,7 @@ class GtPaletteBgColors {
     required this.white,
     required this.warm,
     required this.neutralWarm50,
+    required this.sky,
   });
 
   List<Color> get all => [
@@ -171,6 +173,7 @@ class GtPaletteBgColors {
     warm,
     neutralWarm50,
     white,
+    sky,
   ];
 
   static GtPaletteBgColors lerp(
@@ -188,6 +191,7 @@ class GtPaletteBgColors {
       white: Color.lerp(a?.white, b?.white, t)!,
       neutralWarm50: Color.lerp(a?.neutralWarm50, b?.neutralWarm50, t)!,
       warm: Color.lerp(a?.warm, b?.warm, t)!,
+      sky: Color.lerp(a?.sky, b?.sky, t)!,
     );
   }
 
@@ -203,6 +207,7 @@ class GtPaletteBgColors {
         other.weak == weak &&
         other.white == white &&
         other.warm == warm &&
+        other.sky == sky &&
         other.neutralWarm50 == neutralWarm50;
   }
 

--- a/lib/common/styling/palettes/kids/dark.dart
+++ b/lib/common/styling/palettes/kids/dark.dart
@@ -30,6 +30,7 @@ final class KidsDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.dark,
@@ -41,6 +42,7 @@ final class KidsDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.dark,

--- a/lib/common/styling/palettes/kids/light.dart
+++ b/lib/common/styling/palettes/kids/light.dart
@@ -30,6 +30,7 @@ final class KidsLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.value,
@@ -41,6 +42,7 @@ final class KidsLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.value,

--- a/lib/common/styling/palettes/personal/dark.dart
+++ b/lib/common/styling/palettes/personal/dark.dart
@@ -30,6 +30,7 @@ final class PersonalDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.dark,
@@ -41,6 +42,7 @@ final class PersonalDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.dark,

--- a/lib/common/styling/palettes/personal/light.dart
+++ b/lib/common/styling/palettes/personal/light.dart
@@ -30,6 +30,7 @@ final class PersonalLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.value,
@@ -41,6 +42,7 @@ final class PersonalLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.value,

--- a/lib/common/styling/palettes/sterling_pro/dark.dart
+++ b/lib/common/styling/palettes/sterling_pro/dark.dart
@@ -30,6 +30,7 @@ final class SterlingProDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.dark,
@@ -41,6 +42,7 @@ final class SterlingProDarkPalette extends GtPalette {
           warm: GtColors.yellow25.dark,
           neutralWarm50: GtColors.neutralWarm50.dark,
           weaker: GtColors.neutral25.dark,
+          sky: GtColors.neutral200.dark,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.dark,

--- a/lib/common/styling/palettes/sterling_pro/light.dart
+++ b/lib/common/styling/palettes/sterling_pro/light.dart
@@ -30,6 +30,7 @@ final class SterlingProLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         fill: GtPaletteBgColors(
           strong: GtColors.neutral950.value,
@@ -41,6 +42,7 @@ final class SterlingProLightPalette extends GtPalette {
           warm: GtColors.yellow25.value,
           neutralWarm50: GtColors.neutralWarm50.value,
           weaker: GtColors.neutral25.value,
+          sky: GtColors.skyAlpha5.value,
         ),
         text: GtPaletteTextColors(
           strong: GtColors.neutral950.value,

--- a/lib/widgets/organisms/app_bars/gt_app_bar.dart
+++ b/lib/widgets/organisms/app_bars/gt_app_bar.dart
@@ -20,11 +20,6 @@ enum GtAppBarTitleSize {
       .large => context.textStyles.h5(),
     };
   }
-
-  GtBackButtonSize get buttonSize => switch (this) {
-    .small || .medium => .small,
-    _ => .large,
-  };
 }
 
 /// A highly customizable general-purpose app bar.
@@ -49,6 +44,9 @@ class GtAppBar extends GtStatelessWidget implements PreferredSizeWidget {
   /// The optional height of the app bar.
   final String? heroTag;
 
+  /// The size of the back button.
+  final GtBackButtonSize backButtonSize;
+
   /// Creates a [GtAppBar].
   const GtAppBar({
     this.leading,
@@ -57,6 +55,7 @@ class GtAppBar extends GtStatelessWidget implements PreferredSizeWidget {
     super.key,
     this.implyLeading = true,
     this.titleSize = .small,
+    this.backButtonSize = .large,
     this.heroTag,
   });
 
@@ -70,7 +69,7 @@ class GtAppBar extends GtStatelessWidget implements PreferredSizeWidget {
     Widget? leadingWidget = leading;
 
     if (canImplyLeading && !_hasLeading) {
-      leadingWidget = GtBackButton(size: titleSize.buttonSize);
+      leadingWidget = GtBackButton(size: backButtonSize);
     }
 
     Widget child = Container(
@@ -100,7 +99,7 @@ class GtAppBar extends GtStatelessWidget implements PreferredSizeWidget {
               ),
               Align(
                 alignment: .centerRight,
-                child: GtSquareConstrainedBox(24, child: trailing),
+                child: GtSquareConstrainedBox(32, child: trailing),
               ),
             ],
           ),

--- a/lib/widgets/organisms/cards/gt_alert_card.dart
+++ b/lib/widgets/organisms/cards/gt_alert_card.dart
@@ -80,8 +80,8 @@ class GtAlertIconCard extends GtStatelessWidget {
         child: Stack(
           children: [
             Positioned(
-              top: context.dp(4.px),
-              right: context.dp(4.px),
+              top: context.dp(6.px),
+              right: context.dp(6.px),
               child: GtSquareConstrainedBox(
                 4,
                 child: DecoratedBox(

--- a/lib/widgets/organisms/cards/gt_reminder_banner.dart
+++ b/lib/widgets/organisms/cards/gt_reminder_banner.dart
@@ -25,6 +25,9 @@ class GtReminderBanner extends GtStatelessWidget {
   /// The visual variant of the card, which determines its background color.
   final GtCardVariant variant;
 
+  /// The visual variant of the button.
+  final GtButtonVariant buttonVariant;
+
   /// A callback function that is invoked when the close button is tapped.
   final OnPressed onClose;
 
@@ -35,6 +38,7 @@ class GtReminderBanner extends GtStatelessWidget {
     required this.subtitle,
     this.hidden = false,
     this.variant = .away,
+    this.buttonVariant = .primary,
     required this.icon,
     required this.onClose,
     required this.actionText,
@@ -59,17 +63,17 @@ class GtReminderBanner extends GtStatelessWidget {
             GtSquareConstrainedBox(48, child: icon),
             Expanded(
               child: Column(
-                spacing: context.spacingSm,
                 crossAxisAlignment: .start,
                 children: [
-                  GtText(title.upper, style: context.textStyles.buttonS()),
-                  GtText(subtitle, style: context.textStyles.subHead2xs()),
-                  const GtGap.hSm(),
+                  GtText(title.upper, style: context.textStyles.h7()),
+                  const GtGap.ySm(),
+                  GtText(subtitle, style: context.textStyles.subHeadS()),
+                  const GtGap.yBase(),
                   GtRaisedButton(
                     onPressed: onActionTap,
                     text: actionText,
-                    variant: .verified,
-                    size: .pill,
+                    variant: buttonVariant,
+                    size: .small,
                   ),
                 ],
               ),

--- a/lib/widgets/organisms/cards/gt_tip_card.dart
+++ b/lib/widgets/organisms/cards/gt_tip_card.dart
@@ -70,7 +70,7 @@ class GtTipCard extends GtStatelessWidget {
                       ),
                     ],
                   ),
-                  GtText(
+                  GtRichText(
                     subtitle,
                     style: context.textStyles.bodyXs(
                       color: palette.text.darkerSub,

--- a/lib/widgets/organisms/indicators/gt_slide_indicators.dart
+++ b/lib/widgets/organisms/indicators/gt_slide_indicators.dart
@@ -36,7 +36,7 @@ class GtSlidesIndicator extends GtStatelessWidget {
             children: [
               for (final (index, slide) in controller.slides.indexed)
                 Flexible(
-                  child: _SlideIndicator(
+                  child: GtSlideIndicator(
                     key: ValueKey('slide_indicator_${index}_${slide.hashCode}'),
                     slide: slide,
                     controller: controller,
@@ -52,13 +52,13 @@ class GtSlidesIndicator extends GtStatelessWidget {
   }
 }
 
-class _SlideIndicator extends StatefulWidget {
+class GtSlideIndicator extends StatefulWidget {
   final GtLessonSlideData slide;
   final GtLessonSlideState state;
   final GtLessonslideController controller;
   final Color? indicatorColor;
 
-  const _SlideIndicator({
+  const GtSlideIndicator({
     required this.slide,
     required this.state,
     required this.controller,
@@ -67,10 +67,10 @@ class _SlideIndicator extends StatefulWidget {
   });
 
   @override
-  State<_SlideIndicator> createState() => _SlideIndicatorState();
+  State<GtSlideIndicator> createState() => _GtSlideIndicatorState();
 }
 
-class _SlideIndicatorState extends State<_SlideIndicator>
+class _GtSlideIndicatorState extends State<GtSlideIndicator>
     with TickerProviderStateMixin {
   Future<void>? _setupFuture;
 
@@ -82,7 +82,7 @@ class _SlideIndicatorState extends State<_SlideIndicator>
   }
 
   @override
-  void didUpdateWidget(covariant _SlideIndicator oldWidget) {
+  void didUpdateWidget(covariant GtSlideIndicator oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.state == .active && oldWidget.state != .active) {
       _setupFuture = widget.controller.initialiseProgress(this);
@@ -98,6 +98,7 @@ class _SlideIndicatorState extends State<_SlideIndicator>
     if (widget.state == .done) {
       return GtProgress(
         value: 1,
+        size: 8,
         inactiveColor: inactiveColor,
         color: activeColor,
       );
@@ -105,6 +106,7 @@ class _SlideIndicatorState extends State<_SlideIndicator>
     if (widget.state == .pending) {
       return GtProgress(
         value: 0,
+        size: 8,
         inactiveColor: inactiveColor,
         color: activeColor,
       );
@@ -124,6 +126,7 @@ class _SlideIndicatorState extends State<_SlideIndicator>
               animation: animationController,
               builder: (context, _) {
                 return GtProgress(
+                  size: 8,
                   value: animationController.value,
                   inactiveColor: inactiveColor,
                   color: activeColor,
@@ -142,6 +145,7 @@ class _SlideIndicatorState extends State<_SlideIndicator>
                 final progress = isBuffering ? null : data?.progress;
 
                 return GtProgress(
+                  size: 8,
                   value: progress,
                   inactiveColor: inactiveColor,
                   color: activeColor,
@@ -150,7 +154,11 @@ class _SlideIndicatorState extends State<_SlideIndicator>
             );
           }
 
-          return GtProgress(inactiveColor: inactiveColor, color: activeColor);
+          return GtProgress(
+            size: 8,
+            inactiveColor: inactiveColor,
+            color: activeColor,
+          );
         },
       ),
     );

--- a/lib/widgets/organisms/slides/gt_lesson_slide.dart
+++ b/lib/widgets/organisms/slides/gt_lesson_slide.dart
@@ -27,6 +27,9 @@ class GtLessonSlide extends GtStatefulWidget {
   /// The controller managing slide navigation and media playback for audio-visual slides.
   final GtLessonslideController controller;
 
+  /// The color of the slide indicator.
+  final Color? indicatorColor;
+
   /// Creates a [GtLessonSlide].
   const GtLessonSlide({
     super.key,
@@ -36,6 +39,7 @@ class GtLessonSlide extends GtStatefulWidget {
     required this.onLongPressUp,
     required this.controller,
     this.onSwipeDown,
+    this.indicatorColor,
   });
 
   @override
@@ -102,54 +106,52 @@ class _GtLessonSlideState extends State<GtLessonSlide> {
                 widget.onSwipeDown?.call();
               }
             },
-            child: AnimatedContainer(
-              duration: 500.milliseconds,
-              curve: Curves.decelerate,
+            child: Container(
+              margin: context.insets.onlyDp(
+                top: 24.px,
+                left: 16.px,
+                right: 16.px,
+              ),
+              padding: context.insets.onlyDp(top: 30.px),
               decoration: BoxDecoration(
                 gradient: data.gradient,
-                color: data.color,
+                color: context.palette.bg.weak,
+                borderRadius: BorderRadius.vertical(top: context.radius4Xl),
               ),
               child: SafeArea(
                 bottom: false,
-                child: Stack(
+                child: Column(
+                  crossAxisAlignment: .stretch,
                   children: [
-                    for (final image in (data.backgroundImages ?? []))
-                      GtLessonSlideBackground(
-                        image,
-                        key: ValueKey('bg_${image.hashCode}'),
-                      ),
-                    if (data.header != null)
-                      Positioned.fill(
-                        top: context.spacingsection2xl,
-                        child: GtLessonSlideTitle(
-                          data.header!,
-                          key: ValueKey('title_${data.header.hashCode}'),
-                        ),
-                      ),
-                    Center(
+                    const GtGap.ySectionXl(),
+                    GtLessonSlideTitle(
+                      data.header,
+                      key: ValueKey('title_${data.header.hashCode}'),
+                    ),
+                    Expanded(
                       child: Builder(
                         builder: (context) {
                           return switch (data.slideType) {
                             .image => GtImage(
                               key: ValueKey('img_${data.media.hashCode}'),
-                              fit: .cover,
+                              fit: .contain,
                               useDefaultSize: false,
-                              alignment: data.imageAlignment ?? .bottomCenter,
+                              alignment: data.imageAlignment ?? .center,
+                              width: data.imageSize,
+                              height: data.imageSize,
                               image: data.media as AppImageData,
                             ),
-                            .text => Padding(
-                              padding: context.insets.defaultAllInsets,
+                            .text => SingleChildScrollView(
+                              padding: context.insets.symmetricDp(
+                                vertical: 20.px,
+                                horizontal: 16.px,
+                              ),
                               child: Center(
-                                child: FittedBox(
-                                  fit: .scaleDown,
-                                  child: GtRichText(
-                                    data.text,
-                                    key: ValueKey('txt_${data.text.hashCode}'),
-                                    textAlign: .center,
-                                    style: context.textStyles.h6(
-                                      color: data.textColor,
-                                    ),
-                                  ),
+                                child: GtRichText(
+                                  data.text,
+                                  key: ValueKey('txt_${data.text.hashCode}'),
+                                  textAlign: .center,
+                                  style: context.textStyles.bodyM(),
                                 ),
                               ),
                             ),
@@ -252,16 +254,18 @@ class _GtLessonSlideMediaState extends State<GtLessonSlideMedia>
     final source = widget.controller.mediaSource;
     if (source == null) return const Offstage();
 
-    return IgnorePointer(
-      key: ValueKey(source.hashCode),
-      child: Builder(
-        builder: (context) {
-          if (source.isVideo) return GtVideoPlayer(source.video!);
-          if (source.isYoutube) return GtYoutubePlayer(source.youtube!);
-          if (source.isAudio) return GtLottie(GtNetworkLotties.waveForm);
+    return Center(
+      child: IgnorePointer(
+        key: ValueKey(source.hashCode),
+        child: Builder(
+          builder: (context) {
+            if (source.isVideo) return GtVideoPlayer(source.video!);
+            if (source.isYoutube) return GtYoutubePlayer(source.youtube!);
+            if (source.isAudio) return GtLottie(GtNetworkLotties.waveForm);
 
-          return const SizedBox.shrink();
-        },
+            return const SizedBox.shrink();
+          },
+        ),
       ),
     );
   }
@@ -281,53 +285,29 @@ class GtLessonSlideTitle extends GtStatelessWidget {
   @override
   Widget build(BuildContext context) {
     final styles = context.textStyles;
-    final titleStyle = styles.h4(color: context.palette.staticColors.black);
-    final subStyle = styles.subHeadS(color: context.palette.staticColors.black);
+    final titleStyle = styles.h5();
+    final subStyle = styles.subHeadS();
 
-    Widget subWidget = GtText(
-      data.subTitle,
-      style: data.subtitleStyle ?? subStyle,
-      maxLines: 20,
-    );
-
-    return TweenAnimationBuilder(
-      tween: Tween<Offset>(begin: .zero, end: data.offset),
-      duration: 500.milliseconds,
-      builder: (_, offset, child) {
-        return Transform.translate(
-          offset: offset,
-          child: Padding(
-            padding: context.insets.fromLTRBDp(16.px, 0, 50.px, 0),
-            child: Column(
-              crossAxisAlignment: .start,
-              spacing: context.spacingMd,
-              children: [
-                GtText(
-                  data.title,
-                  style: data.titleStyle ?? titleStyle,
-                  maxLines: 2,
-                  overflow: .ellipsis,
-                ),
-                if (!data.embedSubtitleInCard)
-                  subWidget
-                else
-                  GtCard(
-                    padding: context.insets.symmetricDp(
-                      vertical: 16.px,
-                      horizontal: 12.px,
-                    ),
-                    color: context.palette.staticColors.white,
-                    border: BorderSide(
-                      color: context.palette.staticColors.black,
-                      width: 2,
-                    ),
-                    child: subWidget,
-                  ),
-              ],
-            ),
+    return Padding(
+      padding: context.insets.defaultHorizontalInsets,
+      child: Column(
+        crossAxisAlignment: .start,
+        spacing: context.spacingMd,
+        children: [
+          GtText(
+            data.title,
+            style: titleStyle,
+            maxLines: 2,
+            overflow: .ellipsis,
           ),
-        );
-      },
+          GtText(
+            data.subTitle,
+            style: subStyle,
+            maxLines: 4,
+            overflow: .ellipsis,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/templates/screens/gt_lesson_complete_screen.dart
+++ b/lib/widgets/templates/screens/gt_lesson_complete_screen.dart
@@ -23,7 +23,7 @@ class GtLessonCompleteScreen extends GtStatelessWidget {
   final GtButton primaryButton;
 
   /// The secondary action button (e.g., "back to learn").
-  final GtButton secondaryButton;
+  final GtButton? secondaryButton;
 
   /// Creates a [GtLessonCompleteScreen].
   const GtLessonCompleteScreen({
@@ -41,8 +41,8 @@ class GtLessonCompleteScreen extends GtStatelessWidget {
 
     return Scaffold(
       bottomNavigationBar: GtButtonBottomNavBar(
-        heading: primaryButton,
-        button: secondaryButton,
+        heading: secondaryButton != null ? primaryButton : null,
+        button: secondaryButton ?? primaryButton,
         spacing: context.spacingMd,
       ),
       appBar: const GtAppBar(),

--- a/lib/widgets/templates/slides/gt_lesson_slides.dart
+++ b/lib/widgets/templates/slides/gt_lesson_slides.dart
@@ -32,8 +32,15 @@ class GtLessonSlides extends GtStatefulWidget {
   State<GtLessonSlides> createState() => _GtLessonSlidesState();
 }
 
-class _GtLessonSlidesState extends State<GtLessonSlides> {
+class _GtLessonSlidesState extends State<GtLessonSlides> with RouteAware {
   late GtLessonslideController _controller;
+
+  @override
+  void didPush() {
+    _controller.pause();
+    _controller.reset(notify: false);
+    super.didPush();
+  }
 
   @override
   void initState() {
@@ -53,6 +60,14 @@ class _GtLessonSlidesState extends State<GtLessonSlides> {
     widget.onCancel();
   }
 
+  Gradient? _getGradient(BuildContext context, GtLessonSlideData data) {
+    if (data.color == null && data.gradient == null) {
+      return context.gradients.slideGradient();
+    }
+
+    return data.gradient;
+  }
+
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
@@ -68,34 +83,47 @@ class _GtLessonSlidesState extends State<GtLessonSlides> {
         }
 
         final data = _controller.currentSlide;
+        final bgColor = data.color ?? context.palette.bg.soft;
 
         return Scaffold(
           key: ValueKey(data.hashCode),
-          backgroundColor: data.color,
+          backgroundColor: bgColor,
           extendBody: true,
           extendBodyBehindAppBar: true,
           appBar: GtAppBar(
             trailing: GtCancelButton(onTap: _cancel),
             title: data.title,
           ),
-          body: Stack(
-            children: [
-              GtLessonSlide(
-                key: ValueKey(_controller.currentSlide.hashCode),
-                controller: _controller,
-                onTapNext: _controller.next,
-                onTapPrev: _controller.prev,
-                onLongPressDown: _controller.onLongPressDown,
-                onLongPressUp: _controller.onLongPressUp,
-                onSwipeDown: _cancel,
-              ),
-              Positioned(
-                top: context.spacingSectionSm,
-                left: 0,
-                right: 0,
-                child: SafeArea(child: child!),
-              ),
-            ],
+          body: DecoratedBox(
+            decoration: BoxDecoration(
+              color: bgColor,
+              gradient: _getGradient(context, data),
+            ),
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: SafeArea(
+                    bottom: false,
+                    child: GtLessonSlide(
+                      key: ValueKey(_controller.currentSlide.hashCode),
+                      controller: _controller,
+                      onTapNext: _controller.next,
+                      onTapPrev: _controller.prev,
+                      onLongPressDown: _controller.onLongPressDown,
+                      onLongPressUp: _controller.onLongPressUp,
+                      onSwipeDown: _cancel,
+                      indicatorColor: widget.indicatorColor,
+                    ),
+                  ),
+                ),
+                Positioned(
+                  top: kToolbarHeight + context.dp(30.px),
+                  left: context.dp(32.px),
+                  right: context.dp(32.px),
+                  child: child!,
+                ),
+              ],
+            ),
           ),
         );
       },


### PR DESCRIPTION
## Description

- **Purpose:** Feature & Refactor
- **Issue Link:** #114
- **Summary:** Refactored the lesson slide UI to support new layout parameters, including gradient backgrounds (`GtLessonSlides` / `GtLessonSlideData`), and updated various global color palettes. Additionally, `GtTipCard` was updated to use `GtRichText` for its subtitle widget as requested, and custom button styles are now allowed in `GtReminderBanner`.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-06-02 at 22 36 23" src="https://github.com/user-attachments/assets/abb1df3f-1c66-462e-93dc-9e76fbfd76c9" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-06-02 at 22 36 40" src="https://github.com/user-attachments/assets/56b4e658-4257-4f13-b5f0-dca0edaf9ef2" />


## 🧪 How Has This Been Tested?

- [ ] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:* 
    1. Opened the lesson slides screen to verify the new background gradients and layout updates render correctly.
    2. Checked `GtTipCard` to ensure the rich text subtitle correctly displays formatted text.
    3. Verified `GtReminderBanner` correctly accepts and applies custom button styling.
    4. Navigated through global app elements to verify color palette updates did not cause contrast/display issues.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [ ] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
