### PR TITLE
[refactor]: integrate onPressed into GtCard and enhance GtAddressCard…

### DIFF
--- a/gallery/lib/organisms/cards/gt_card.dart
+++ b/gallery/lib/organisms/cards/gt_card.dart
@@ -272,6 +272,20 @@ Widget buildGtCardUseCase(BuildContext context) {
                 ),
                 variant: cardVariant,
               ),
+              const GtGap.yBase(),
+              GtAddressCard(
+                line1: context.knobs.string(
+                  label: "Address Line 1",
+                  initialValue: "210 Sanusi Street",
+                ),
+                line2: context.knobs.string(
+                  label: "Address Line 2",
+                  initialValue: "Surulere, Lagos Nigeria 234768",
+                ),
+                line1Style: context.textStyles.subHeadS(),
+                borderStyle: .none,
+                variant: cardVariant,
+              ),
               const GalleryPageSectionHeader(title: "GtHelpCard"),
               GtHelpCard(
                 title: "Need more help?",

--- a/lib/widgets/organisms/cards/gt_address_card.dart
+++ b/lib/widgets/organisms/cards/gt_address_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
 /// A simple card for displaying a physical address.
@@ -6,18 +7,42 @@ class GtAddressCard extends GtStatelessWidget {
   /// The first line of the address.
   final String line1;
 
+  /// The text style to apply to [line1].
+  ///
+  /// If null, defaults to the body medium text style from the theme.
+  final TextStyle? line1Style;
+
   /// The second line of the address (e.g., city, state, zip).
   final String line2;
 
+  /// The text style to apply to [line2].
+  ///
+  /// If null, defaults to the standard text style.
+  final TextStyle? line2Style;
+
   /// The visual variant of the card, which determines its background and border colors.
   final GtCardVariant variant;
+
+  /// The style of the border drawn around the card.
+  ///
+  /// Defaults to [BorderStyle.solid].
+  final BorderStyle borderStyle;
+
+  /// Callback invoked when the user taps on the card.
+  ///
+  /// If null, the card will not be interactive.
+  final OnPressed? onPressed;
 
   /// Creates a [GtAddressCard].
   const GtAddressCard({
     super.key,
     required this.line1,
     required this.line2,
+    this.onPressed,
+    this.line1Style,
+    this.line2Style,
     this.variant = .normal,
+    this.borderStyle = .solid,
   });
 
   @override
@@ -27,14 +52,15 @@ class GtAddressCard extends GtStatelessWidget {
 
     return GtCard(
       padding: context.insets.allDp(16.px),
-      border: BorderSide(color: borderColor),
       variant: variant,
+      onPressed: onPressed,
+      border: BorderSide(color: borderColor, style: borderStyle),
       child: Column(
         spacing: context.spacingSm,
         crossAxisAlignment: .stretch,
         children: [
-          GtText(line1, style: context.textStyles.bodyM()),
-          GtText(line2),
+          GtText(line1, style: line1Style ?? context.textStyles.bodyM()),
+          GtText(line2, style: line2Style),
         ],
       ),
     );

--- a/lib/widgets/organisms/cards/gt_product_card.dart
+++ b/lib/widgets/organisms/cards/gt_product_card.dart
@@ -43,24 +43,21 @@ class GtProductCard extends GtStatelessWidget {
       );
     }
 
-    return GtInkWell(
-      borderRadius: context.borderRadius2Xl,
-      onTap: onTap,
-      child: GtCard(
-        padding: context.insets.allDp(12.px),
-        variant: variant,
-        child: Column(
-          crossAxisAlignment: .start,
-          mainAxisAlignment: .center,
-          spacing: context.spacingSm,
-          mainAxisSize: .min,
-          children: [
-            GtIcon.withColor(icon, color: iconColor, size: 24),
-            if (footer == null) const Spacer() else const GtGap.ySm(),
-            GtText(name, style: context.textStyles.subHeadS(), maxLines: 1),
-            ?footer,
-          ],
-        ),
+    return GtCard(
+      padding: context.insets.allDp(12.px),
+      variant: variant,
+      onPressed: onTap,
+      child: Column(
+        crossAxisAlignment: .start,
+        mainAxisAlignment: .center,
+        spacing: context.spacingSm,
+        mainAxisSize: .min,
+        children: [
+          GtIcon.withColor(icon, color: iconColor, size: 24),
+          if (footer == null) const Spacer() else const GtGap.ySm(),
+          GtText(name, style: context.textStyles.subHeadS(), maxLines: 1),
+          ?footer,
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Description

- **Purpose:** Feature / Refactor / Documentation
- **Issue Link:** #124
- **Summary:** Made the `GtAddressCard` widget more configurable by exposing new styling and interactivity properties (`line1Style`, `line2Style`, `borderStyle`, and `onPressed`). Added documentation comments for all properties to improve developer experience. Included a new interactive use case for `GtAddressCard` in the gallery app using `context.knobs`. Additionally, refactored `GtProductCard` to use the built-in `onPressed` parameter of `GtCard` instead of wrapping it in a `GtInkWell`, simplifying the widget tree.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [ ] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)

<img width="425" height="700" alt="Screenshot 2026-06-17 at 16 00 22" src="https://github.com/user-attachments/assets/c9e58ecc-7818-43cd-9f76-f27a2e65b6c6" />


## 🧪 How Has This Been Tested?

- [ ] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:* 
    1. Launch the gallery application.
    2. Navigate to the Cards section.
    3. Verify that the new `GtAddressCard` use case correctly displays the "210 Sanusi Street" address and allows updating values via knobs.
    4. Confirm that the card border style renders appropriately and responds to tap interactions.
    5. Check that `GtProductCard` tap interactions continue to work as expected after the refactoring.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
