### PR TITLE
[FEAT]: hideable Y-axis labels for line charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,16 @@ migrate_working_dir/
 gallery/lib/main.directories.g.dart
 gallery/android/local.properties
 gallery/lib/main.directories.g.dart
+
+# FVM Version Cache
+.fvm/
+.fvmrc
+pubspec.lock
+ios/Podfile.lock
+.idea/
+branch_structure.json
+temp_auto_push.bat
+temp_interactive_push.bat
+.claude/
+.idea/macos/Flutter/
+macos/Flutter/

--- a/gallery/lib/molecules/tiles/gt_list_tile.dart
+++ b/gallery/lib/molecules/tiles/gt_list_tile.dart
@@ -828,6 +828,7 @@ Widget gtListTileAllUseCase(BuildContext context) {
     GtStatListTile.asCard(
       "money out",
       value: "N400,070",
+      isPositive: false,
       icon: GtIcon.withColor(
         GtIcons.trendDown,
         color: context.palette.error.base,

--- a/gallery/lib/organisms/data_viz/gt_data_viz.dart
+++ b/gallery/lib/organisms/data_viz/gt_data_viz.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 @widgetbook.UseCase(name: 'GtGuageChart', type: GtGuageChart)
@@ -125,15 +126,9 @@ Widget buildGtLineChartUsecase(BuildContext context) {
                 title: "Total Balance",
                 maxValue: 100_000_000,
                 color: context.palette.bg.strong,
-                gradient: LinearGradient(
-                  colors: [
-                    context.palette.error.base,
-                    context.palette.away.base,
-                    context.palette.success.base,
-                  ],
-                  stops: [0.2, 0.6, 1],
-                  begin: .bottomCenter,
-                  end: .topCenter,
+                hideYAxisLabels: context.knobs.boolean(
+                  label: "Hide Y Axis Labels",
+                  initialValue: false,
                 ),
                 controller: _calendarCtrl,
                 onRangeUpdate: (range) {

--- a/lib/common/styling/gt_gradients.dart
+++ b/lib/common/styling/gt_gradients.dart
@@ -57,6 +57,22 @@ class GtGradients {
     );
   }
 
+  /// A gradient tailored for line charts.
+  ///
+  /// Transitions from the error color at the bottom to the success color at the top.
+  LinearGradient get chartGradient {
+    return LinearGradient(
+      colors: [
+        context.palette.error.base,
+        context.palette.away.base,
+        context.palette.success.base,
+      ],
+      stops: [0.2, 0.6, 1],
+      begin: .bottomCenter,
+      end: .topCenter,
+    );
+  }
+
   /// Creates a two-tone linear gradient.
   ///
   /// Transitions from the provided [light] color at the top-left to the [dark] color at the bottom-right.

--- a/lib/widgets/molecules/tiles/gt_info_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_info_tiles.dart
@@ -107,6 +107,9 @@ class GtStatListTile extends GtStatelessWidget {
   /// If null, defaults to [GtTextStyles.buttonXs] with a subtle color.
   final TextStyle? titleStyle;
 
+  /// if true, the value will be displayed in green color, else in red color
+  final bool isPositive;
+
   /// Internal flag to determine if the tile should be wrapped in a [GtCard].
   final bool _asCard;
 
@@ -119,6 +122,7 @@ class GtStatListTile extends GtStatelessWidget {
     this.titleStyle,
     this.valueStyle,
     this.onTap,
+    this.isPositive = true,
   }) : _asCard = false;
 
   /// Creates a [GtStatListTile] that is automatically wrapped in a [GtCard].
@@ -129,12 +133,15 @@ class GtStatListTile extends GtStatelessWidget {
     this.icon,
     this.titleStyle,
     this.valueStyle,
+    this.isPositive = true,
     this.onTap,
   }) : _asCard = true;
 
   @override
   Widget build(BuildContext context) {
-    final style = valueStyle ?? context.textStyles.h5();
+    final palette = context.palette;
+    final valueColor = isPositive ? palette.success.base : palette.error.base;
+    final style = valueStyle ?? context.textStyles.h5(color: valueColor);
     final labelStyle = (titleStyle ?? context.textStyles.buttonXs()).copyWith(
       color: context.palette.text.sub,
     );

--- a/lib/widgets/molecules/tiles/gt_info_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_info_tiles.dart
@@ -48,7 +48,7 @@ class GtInfoListTile extends GtStatelessWidget {
     final styles = context.textStyles;
     final textColors = context.palette.text;
     final style = textStyle ?? styles.subHead3M(heightPx: 0);
-    final hintStyle = (labelStyle ?? styles.bodyS(color: textColors.sub));
+    final hintStyle = labelStyle ?? styles.bodyS(color: textColors.sub);
 
     return GtInkWell(
       borderRadius: .zero,
@@ -142,8 +142,8 @@ class GtStatListTile extends GtStatelessWidget {
     final palette = context.palette;
     final valueColor = isPositive ? palette.success.base : palette.error.base;
     final style = valueStyle ?? context.textStyles.h5(color: valueColor);
-    final labelStyle = (titleStyle ?? context.textStyles.buttonXs()).copyWith(
-      color: context.palette.text.sub,
+    final defaultTitleStyle = context.textStyles.buttonXs(
+      color: palette.text.sub,
     );
 
     Widget child = Column(
@@ -154,7 +154,12 @@ class GtStatListTile extends GtStatelessWidget {
           spacing: context.spacingSm,
           children: [
             ?icon,
-            Expanded(child: GtText(title.upper, style: labelStyle)),
+            Expanded(
+              child: GtText(
+                title.upper,
+                style: titleStyle ?? defaultTitleStyle,
+              ),
+            ),
           ],
         ),
         GtText(value, style: style),
@@ -234,9 +239,9 @@ class GtInputListTile extends GtStatelessWidget {
   @override
   Widget build(BuildContext context) {
     final style = textStyle ?? context.textStyles.subHeadS();
-    final hintStyle = (labelStyle ?? context.textStyles.bodyXs()).copyWith(
-      color: context.palette.text.sub,
-    );
+    final hintStyle =
+        (labelStyle ??
+        context.textStyles.bodyXs(color: context.palette.text.sub));
 
     Widget child = Column(
       spacing: context.spacingSm,

--- a/lib/widgets/molecules/tiles/gt_selection_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_selection_tiles.dart
@@ -315,7 +315,7 @@ class GtCountrySelectionListTile extends GtStatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = context.textStyles.bodyS();
+    final style = context.textStyles.bodyS(color: context.palette.text.soft);
     final size = context.dp(34.px);
 
     return GtInkWell(
@@ -338,10 +338,7 @@ class GtCountrySelectionListTile extends GtStatelessWidget {
               TextSpan(
                 children: [
                   if (showCountryCode)
-                    TextSpan(
-                      text: "${value.countryCode} ",
-                      style: style.copyWith(color: context.palette.text.soft),
-                    ),
+                    TextSpan(text: "${value.countryCode} ", style: style),
                   TextSpan(text: value.displayName.capitalise(), style: style),
                 ],
               ),

--- a/lib/widgets/organisms/data_viz/gt_line_chart.dart
+++ b/lib/widgets/organisms/data_viz/gt_line_chart.dart
@@ -35,6 +35,11 @@ class GtLineChartArea extends StatefulWidget {
   /// The minimum value of the y-axis. If null, it will be calculated from the data.
   final num? min;
 
+  /// Controls the visibility of the Y-axis labels.
+  ///
+  /// If `true`, the labels will be hidden. Defaults to `false`.
+  final bool hideYAxisLabels;
+
   /// Creates a new [GtLineChartArea].
   ///
   /// The [items] and [color] parameters must not be null.
@@ -47,6 +52,7 @@ class GtLineChartArea extends StatefulWidget {
     required this.color,
     this.max,
     this.min,
+    this.hideYAxisLabels = false,
   });
 
   @override
@@ -131,7 +137,8 @@ class _GtLineChartAreaState extends State<GtLineChartArea> {
                     painter: GtTrendPainter(
                       values,
                       color: widget.color,
-                      gradient: widget.gradient,
+                      gradient:
+                          widget.gradient ?? context.gradients.chartGradient,
                       maxValue: _max,
                       selectedIndex: index,
                       selectedFillColor: context.palette.bg.weak,
@@ -139,16 +146,18 @@ class _GtLineChartAreaState extends State<GtLineChartArea> {
                     child: Stack(
                       clipBehavior: Clip.none,
                       children: [
-                        Positioned(
-                          top: 0,
-                          right: 0,
-                          child: GtText(yMax, style: yTextStyle),
-                        ),
-                        Positioned(
-                          bottom: 0,
-                          right: 0,
-                          child: GtText(yMin, style: yTextStyle),
-                        ),
+                        if (!widget.hideYAxisLabels) ...[
+                          Positioned(
+                            top: 0,
+                            right: 0,
+                            child: GtText(yMax, style: yTextStyle),
+                          ),
+                          Positioned(
+                            bottom: 0,
+                            right: 0,
+                            child: GtText(yMin, style: yTextStyle),
+                          ),
+                        ],
                         if (index != null)
                           _ChartTooltip(
                             item: widget.items.elementAtOrNull(index),

--- a/lib/widgets/templates/data_viz/gt_line_chart_container.dart
+++ b/lib/widgets/templates/data_viz/gt_line_chart_container.dart
@@ -50,6 +50,11 @@ class GtLineChartContainer extends GtStatelessWidget with GtBottomSheetMixin {
   /// Defaults to 165.0.
   final double height;
 
+  /// Controls the visibility of the Y-axis labels.
+  ///
+  /// If `true`, the labels will be hidden. Defaults to `false`.
+  final bool hideYAxisLabels;
+
   /// Creates a new [GtLineChartContainer].
   ///
   /// The [items], [calendarTitle], [title], [color], [controller], and
@@ -67,6 +72,7 @@ class GtLineChartContainer extends GtStatelessWidget with GtBottomSheetMixin {
     this.gradient,
     this.width,
     this.height = 165,
+    this.hideYAxisLabels = false,
   });
 
   /// Retrieves the currently selected date range from the [controller].
@@ -159,6 +165,7 @@ class GtLineChartContainer extends GtStatelessWidget with GtBottomSheetMixin {
               color: color,
               gradient: gradient,
               max: maxValue,
+              hideYAxisLabels: hideYAxisLabels,
               key: ValueKey(
                 Object.hash(items, width, height, color, gradient, maxValue),
               ),


### PR DESCRIPTION
## Description

- **Purpose:** Refactor / Feature
- **Issue Link:** Closes #126
- **Summary:** 
  - Added a `hideYAxisLabels` property to `GtLineChartArea` and `GtLineChartContainer` to allow hiding the minimum and maximum text labels on the Y-axis.
  - Extracted the default line chart gradient into `GtGradients.chartGradient` for better reuse across the app.
  - Added an `isPositive` boolean flag to `GtStatListTile` to dynamically set the value text color (green for positive, red for negative).
  - Updated the Widgetbook gallery with knobs to test the new `hideYAxisLabels` and `isPositive` properties.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)

https://github.com/user-attachments/assets/e76b523f-453a-4a2e-bce1-e64b6dd4729a


<img width="427" height="924" alt="Screenshot 2026-06-21 at 11 43 41" src="https://github.com/user-attachments/assets/8ac1c885-c190-494c-a6f9-d3c1f1d73d2a" />

## 🧪 How Has This Been Tested?

- [ ] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated (Widgetbook gallery updated)
- [x] Manual Testing (Describe steps below)
  - *Steps:* 
    1. Open Widgetbook.
    2. Navigate to the `GtLineChartArea` use case and toggle the **"Hide Y Axis Labels"** knob to verify the text toggles correctly.
    3. Navigate to the `GtStatListTile` use case and verify that the "money out" text renders in the correct error color.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.