### PR TITLE
[FEAT]: implement persistent theme state management with GtThemeState…

### DIFF
--- a/.github/workflows/deploy_gallery.yaml
+++ b/.github/workflows/deploy_gallery.yaml
@@ -34,7 +34,7 @@ jobs:
         run: flutter pub get
 
       - name: Build Widgetbook
-        run: cd gallery && dart run build_runner build -d && flutter build web --target lib/main.dart --base-href "/${{ github.event.repository.name }}/"
+        run: cd gallery && dart run build_runner build -d && flutter build web --no-wasm --target lib/main.dart --base-href "/${{ github.event.repository.name }}/"
 
       - name: Build Docs
         run: pwd && dart doc --output=gallery/build/web/api

--- a/.github/workflows/deploy_gallery.yaml
+++ b/.github/workflows/deploy_gallery.yaml
@@ -34,7 +34,7 @@ jobs:
         run: flutter pub get
 
       - name: Build Widgetbook
-        run: cd gallery && dart run build_runner build -d && flutter build web --wasm --target lib/main.dart --base-href "/${{ github.event.repository.name }}/"
+        run: cd gallery && dart run build_runner build -d && flutter build web --target lib/main.dart --base-href "/${{ github.event.repository.name }}/"
 
       - name: Build Docs
         run: pwd && dart doc --output=gallery/build/web/api

--- a/gallery/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/gallery/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -61,6 +61,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin flutter_plugin_android_lifecycle, io.flutter.plugins.flutter_plugin_android_lifecycle.FlutterAndroidLifecyclePlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin flutter_secure_storage, com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new io.flutter.plugins.imagepicker.ImagePickerPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin image_picker_android, io.flutter.plugins.imagepicker.ImagePickerPlugin", e);

--- a/gallery/ios/Podfile.lock
+++ b/gallery/ios/Podfile.lock
@@ -141,6 +141,9 @@ PODS:
   - flutter_inappwebview_ios/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 6.0.3)
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
   - GoogleAdsOnDeviceConversion (3.5.0):
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
@@ -245,6 +248,7 @@ DEPENDENCIES:
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
+  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
@@ -302,6 +306,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_inappwebview_ios:
     :path: ".symlinks/plugins/flutter_inappwebview_ios/ios"
+  flutter_secure_storage_darwin:
+    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   just_audio:
@@ -346,6 +352,7 @@ SPEC CHECKSUMS:
   FirebaseSessions: 0e5f64cd99400275798fcb5e2b773dd000ca02c1
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
   GoogleAdsOnDeviceConversion: 914d95386d0dd6815e8b1d70c465fe1d13312a1e
   GoogleAppMeasurement: 01e991b4c0c025dd66558dbc5133b5d70ccdf88e
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7

--- a/gallery/lib/addons/gt_theme_addon.dart
+++ b/gallery/lib/addons/gt_theme_addon.dart
@@ -1,20 +1,8 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 import 'package:widgetbook/widgetbook.dart';
-
-/// A setting state that holds both the selected [GtTheme] and [ThemeMode].
-class GtThemeSetting extends AppEquatable {
-  const GtThemeSetting({required this.theme, required this.mode});
-
-  final GtTheme theme;
-  final ThemeMode mode;
-
-  @override
-  List<Object?> get props => [theme, mode];
-}
 
 /// A custom Addon that exposes two configuration fields in Widgetbook:
 /// - Theme: Dropdown to pick the active GtTheme (e.g., Personal, Kids).

--- a/gallery/lib/gallery_cover.dart
+++ b/gallery/lib/gallery_cover.dart
@@ -1,29 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
-import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
-// ignore: depend_on_referenced_packages
-import 'package:provider/provider.dart';
 
 @widgetbook.UseCase(name: 'Cover', type: DesignSystemCover)
 Widget buildCover(BuildContext context) {
-  final state = context.watch<GtThemeState>();
-  final theme = context.knobs.object.dropdown(
-    label: "Switch Theme",
-    initialOption: state.themeSetting.theme,
-    options: kAllThemes,
-    labelBuilder: (value) => value.name.capitalise(),
-  );
-  final mode = context.knobs.object.dropdown(
-    label: "Switch Theme Mode",
-    initialOption: state.themeSetting.mode,
-    options: ThemeMode.values,
-    labelBuilder: (value) => value.name.capitalise(),
-  );
-
-  state.switchTheme(theme);
-  state.changeMode(mode);
   return const DesignSystemCover();
 }
 

--- a/gallery/lib/gallery_cover.dart
+++ b/gallery/lib/gallery_cover.dart
@@ -1,9 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+// ignore: depend_on_referenced_packages
+import 'package:provider/provider.dart';
 
 @widgetbook.UseCase(name: 'Cover', type: DesignSystemCover)
 Widget buildCover(BuildContext context) {
+  final state = context.watch<GtThemeState>();
+  final theme = context.knobs.object.dropdown(
+    label: "Switch Theme",
+    initialOption: state.themeSetting.theme,
+    options: kAllThemes,
+    labelBuilder: (value) => value.name.capitalise(),
+  );
+  final mode = context.knobs.object.dropdown(
+    label: "Switch Theme Mode",
+    initialOption: state.themeSetting.mode,
+    options: ThemeMode.values,
+    labelBuilder: (value) => value.name.capitalise(),
+  );
+
+  state.switchTheme(theme);
+  state.changeMode(mode);
   return const DesignSystemCover();
 }
 

--- a/gallery/lib/main.dart
+++ b/gallery/lib/main.dart
@@ -3,8 +3,6 @@ import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
-// ignore: depend_on_referenced_packages
-import 'package:provider/provider.dart';
 
 import 'main.directories.g.dart';
 import 'addons/gt_theme_addon.dart';
@@ -107,23 +105,8 @@ void main() {
   locator.registerLazySingleton<AppConfig>(() {
     return GalleryConfig();
   });
-  locator.registerLazySingleton<AppStorageService>(() {
-    return AppSecureStorageService();
-  });
-  locator.registerLazySingleton<GtThemeState>(() {
-    return GtThemeState(locator(), kPersonalTheme);
-  });
-  runApp(
-    GtStateWrapper(
-      providers: [
-        ChangeNotifierProvider<GtThemeState>(
-          create: (_) => locator(),
-          lazy: true,
-        ),
-      ],
-      child: const WidgetbookApp(),
-    ),
-  );
+
+  runApp(const WidgetbookApp());
 }
 
 final ValueNotifier<GtThemeSetting> themeNotifier = ValueNotifier(
@@ -136,9 +119,9 @@ class WidgetbookApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final state = context.watch<GtThemeState>();
-    final activeTheme = state.themeSetting.theme;
-    final activeMode = state.themeSetting.mode;
+    final state = GtThemeSetting(theme: kPersonalTheme, mode: .system);
+    final activeTheme = state.theme;
+    final activeMode = state.mode;
 
     return GtThemeProvider(
       theme: activeTheme,

--- a/gallery/lib/main.dart
+++ b/gallery/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+// ignore: depend_on_referenced_packages
+import 'package:provider/provider.dart';
 
 import 'main.directories.g.dart';
 import 'addons/gt_theme_addon.dart';
@@ -105,7 +107,23 @@ void main() {
   locator.registerLazySingleton<AppConfig>(() {
     return GalleryConfig();
   });
-  runApp(const WidgetbookApp());
+  locator.registerLazySingleton<AppStorageService>(() {
+    return AppSecureStorageService();
+  });
+  locator.registerLazySingleton<GtThemeState>(() {
+    return GtThemeState(locator(), kPersonalTheme);
+  });
+  runApp(
+    GtStateWrapper(
+      providers: [
+        ChangeNotifierProvider<GtThemeState>(
+          create: (_) => locator(),
+          lazy: true,
+        ),
+      ],
+      child: const WidgetbookApp(),
+    ),
+  );
 }
 
 final ValueNotifier<GtThemeSetting> themeNotifier = ValueNotifier(
@@ -118,27 +136,26 @@ class WidgetbookApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GenericListener(
-      valueListenable: themeNotifier,
-      builder: (activeTheme) {
-        return GtThemeProvider(
-          theme: activeTheme.theme,
-          child: Widgetbook.material(
-            initialRoute: "?path=designsystemcover/cover",
-            directories: directories,
-            darkTheme: activeTheme.theme.materialDark,
-            lightTheme: activeTheme.theme.materialLight,
-            themeMode: activeTheme.mode,
-            addons: [
-              ViewportAddon(Viewports.all),
-              GtThemeAddon(themes: kAllThemes, themeNotifier: themeNotifier),
-              InspectorAddon(),
-              TextScaleAddon(max: 1.5),
-              ZoomAddon(),
-            ],
-          ),
-        );
-      },
+    final state = context.watch<GtThemeState>();
+    final activeTheme = state.themeSetting.theme;
+    final activeMode = state.themeSetting.mode;
+
+    return GtThemeProvider(
+      theme: activeTheme,
+      child: Widgetbook.material(
+        initialRoute: "?path=designsystemcover/cover",
+        directories: directories,
+        darkTheme: activeTheme.materialDark,
+        lightTheme: activeTheme.materialLight,
+        themeMode: activeMode,
+        addons: [
+          ViewportAddon(Viewports.all),
+          GtThemeAddon(themes: kAllThemes, themeNotifier: themeNotifier),
+          InspectorAddon(),
+          TextScaleAddon(max: 1.5),
+          ZoomAddon(),
+        ],
+      ),
     );
   }
 }

--- a/gallery/lib/molecules/inputs/gt_inputs.dart
+++ b/gallery/lib/molecules/inputs/gt_inputs.dart
@@ -185,7 +185,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
               suffix: suffix.$2,
               textAlign: textAlign,
               decoration: decoration.$2,
-              validator: (_) => "Field is invalid",
+              validator: AppValidators.required,
               helperText: helperText,
             ),
             const GtGap.yXl(),
@@ -198,7 +198,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
               suffix: suffix.$2,
               textAlign: textAlign,
               decoration: decoration.$2,
-              validator: (_) => "Field is invalid",
+              validator: AppValidators.required,
               helperText: helperText,
             ),
             const GtGap.yXl(),
@@ -266,7 +266,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
               controller: _inputCtrl12,
               hintText: "Search for a country",
               decoration: decoration.$2,
-              validator: (_) => "Field is invalid",
+              validator: AppValidators.required,
               textInputAction: TextInputAction.done,
               builder: (query) async {
                 final countries = await AppCountryUtility.searchCountries(
@@ -284,6 +284,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
               controller: _inputCtrl14,
               decoration: decoration.$2,
               options: allCountries,
+              validator: AppValidators.required,
               sheetTitle: "Select Country",
               label: "Select a country [Default tiles with Title]",
             ),
@@ -293,6 +294,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
               decoration: decoration.$2,
               options: allCountries,
               label: "Select a country [Custom tiles]",
+              validator: AppValidators.required,
               optionBuilder: (value, value2) {
                 return GtCountrySelectionListTile(
                   value.value,
@@ -311,6 +313,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
               decoration: decoration.$2,
               options: allCountries,
               label: "Select a country [Custom list]",
+              validator: AppValidators.required,
               optionsBuilder: (options, controller, scrollContoller) {
                 return ListView.separated(
                   padding: context.insets.allDp(16.px),

--- a/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import firebase_core
 import firebase_crashlytics
 import firebase_messaging
 import flutter_inappwebview_macos
+import flutter_secure_storage_darwin
 import just_audio
 import local_auth_darwin
 import share_plus
@@ -32,6 +33,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/gallery/macos/Podfile.lock
+++ b/gallery/macos/Podfile.lock
@@ -111,6 +111,9 @@ PODS:
   - flutter_inappwebview_macos (0.0.1):
     - FlutterMacOS
     - OrderedSet (~> 6.0.3)
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - GoogleAppMeasurement/Core (12.13.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
@@ -203,6 +206,7 @@ DEPENDENCIES:
   - firebase_crashlytics (from `Flutter/ephemeral/.symlinks/plugins/firebase_crashlytics/macos`)
   - firebase_messaging (from `Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos`)
   - flutter_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos`)
+  - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - just_audio (from `Flutter/ephemeral/.symlinks/plugins/just_audio/darwin`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
@@ -254,6 +258,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos
   flutter_inappwebview_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos
+  flutter_secure_storage_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
   just_audio:
@@ -294,6 +300,7 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 4801ab93a543ef8fedfb40ae2f66d03e3fdcb864
   FirebaseSessions: 0e5f64cd99400275798fcb5e2b773dd000ca02c1
   flutter_inappwebview_macos: bdf207b8f4ebd58e86ae06cd96b147de99a67c9b
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   GoogleAppMeasurement: 01e991b4c0c025dd66558dbc5133b5d70ccdf88e
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7

--- a/gallery/macos/Runner.xcodeproj/project.pbxproj
+++ b/gallery/macos/Runner.xcodeproj/project.pbxproj
@@ -195,7 +195,6 @@
 				9B3C616BA679D54965676537 /* Pods-RunnerTests.release.xcconfig */,
 				5616CA8BFADE64A270E5C0DF /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -590,8 +589,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 9QCSGLAC6M;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -722,8 +723,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 9QCSGLAC6M;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -742,8 +745,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 9QCSGLAC6M;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/gallery/macos/Runner/DebugProfile.entitlements
+++ b/gallery/macos/Runner/DebugProfile.entitlements
@@ -6,9 +6,13 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.example.gallery</string>
+	</array>
 </dict>
 </plist>

--- a/gallery/macos/Runner/Release.entitlements
+++ b/gallery/macos/Runner/Release.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.example.gallery</string>
+	</array>
 </dict>
 </plist>

--- a/gallery/pubspec.lock
+++ b/gallery/pubspec.lock
@@ -681,8 +681,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.0.32"
-      resolved-ref: "0d8543861b51c3bd1cafbb74c603afbf0c5b3c59"
+      ref: "v0.0.33"
+      resolved-ref: "1db74b23bed371d1824c502ec45d5c6738edbb62"
       url: "https://github.com/gofinancials/gt_mobile_foundation.git"
     source: git
     version: "0.0.1"

--- a/gallery/pubspec.lock
+++ b/gallery/pubspec.lock
@@ -595,6 +595,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.34"
+  flutter_secure_storage:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -633,8 +681,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.0.30"
-      resolved-ref: d17e4b47a255b7523e08db7e006aae55698713b6
+      ref: "v0.0.32"
+      resolved-ref: "0d8543861b51c3bd1cafbb74c603afbf0c5b3c59"
       url: "https://github.com/gofinancials/gt_mobile_foundation.git"
     source: git
     version: "0.0.1"

--- a/gallery/pubspec.lock
+++ b/gallery/pubspec.lock
@@ -681,8 +681,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.0.33"
-      resolved-ref: "1db74b23bed371d1824c502ec45d5c6738edbb62"
+      ref: "v0.0.34"
+      resolved-ref: e65bdfe81c2470f819a932cb8e2dbdb09ee5190d
       url: "https://github.com/gofinancials/gt_mobile_foundation.git"
     source: git
     version: "0.0.1"

--- a/gallery/pubspec.yaml
+++ b/gallery/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.32
+      ref: v0.0.33
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/gallery/pubspec.yaml
+++ b/gallery/pubspec.yaml
@@ -17,8 +17,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.30
-
+      ref: v0.0.32
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/gallery/pubspec.yaml
+++ b/gallery/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.33
+      ref: v0.0.34
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -5,5 +5,6 @@ export 'painters/painters.dart';
 export 'physics/physics.dart';
 export 'providers/providers.dart';
 export 'router/router.dart';
+export 'state/state.dart';
 export 'styling/styling.dart';
 export 'utilities/utilities.dart';

--- a/lib/common/data/data.dart
+++ b/lib/common/data/data.dart
@@ -6,6 +6,7 @@ export 'gt_decoration_image_style.dart';
 export 'gt_input_data.dart';
 export 'gt_keycell_data.dart';
 export 'gt_slide_data.dart';
+export 'gt_theme_setting.dart';
 export 'gt_transaction_category.dart';
 export 'gt_wheel_scroll_data.dart';
 export 'gt_widget_pair.dart';

--- a/lib/common/data/gt_theme_setting.dart
+++ b/lib/common/data/gt_theme_setting.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// A configuration class that encapsulates the current theme settings.
+///
+/// This state object holds both the selected design system [GtTheme] and the
+/// application's [ThemeMode] (e.g., light, dark, or system). It is typically
+/// used by the theme management system to maintain the active theme state.
+class GtThemeSetting extends AppEquatable {
+  /// Creates a [GtThemeSetting] with the given [theme] and [mode].
+  const GtThemeSetting({required this.theme, required this.mode});
+
+  /// The active design system theme.
+  final GtTheme theme;
+
+  /// The active theme mode (e.g., [ThemeMode.system], [ThemeMode.light], or [ThemeMode.dark]).
+  final ThemeMode mode;
+
+  @override
+  List<Object?> get props => [theme, mode];
+}

--- a/lib/common/state/gt_theme_state.dart
+++ b/lib/common/state/gt_theme_state.dart
@@ -77,6 +77,16 @@ class GtThemeState extends StateModel {
     await _service.setItem(AppStorageKey.themeName, theme.name);
   }
 
+  bool isInDarkMode(BuildContext context) {
+    final mode = _themeSetting.mode;
+    if (mode != .system) return mode == .dark;
+
+    final themeBrightness = Theme.maybeBrightnessOf(context);
+    final platformBrightness = MediaQuery.maybePlatformBrightnessOf(context);
+
+    return (themeBrightness ?? platformBrightness) == .dark;
+  }
+
   @override
   void dispose() {
     _service.unWatchItems([AppStorageKey.themeMode, AppStorageKey.themeName]);

--- a/lib/common/state/gt_theme_state.dart
+++ b/lib/common/state/gt_theme_state.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// Manages the application's global theme state, including the active design system theme
+/// and brightness mode.
+///
+/// This state model interfaces with [AppStorageService] to persist user theme preferences
+/// across sessions. It automatically listens for changes to the stored theme mode and
+/// theme name, updating the active [GtThemeSetting] and notifying listeners to trigger
+/// a UI rebuild.
+///
+/// Typical usage involves providing this state via a provider and accessing it to read
+/// the current theme or invoke [changeMode] and [switchTheme] to update preferences.
+class GtThemeState extends StateModel {
+  final AppStorageService _service;
+  late GtThemeSetting _themeSetting;
+
+  GtThemeState(this._service, GtTheme initialTheme) {
+    _themeSetting = GtThemeSetting(theme: initialTheme, mode: .system);
+    _seedSetting();
+    _observeTheme();
+  }
+
+  GtThemeSetting get themeSetting => _themeSetting;
+
+  Future<void> _seedSetting() async {
+    final storedValues = await _getStoredValues();
+    final mode = _resolveMode(storedValues[AppStorageKey.themeMode]);
+    final theme = _resolveTheme(storedValues[AppStorageKey.themeName]);
+    _updateSetting(mode: mode, theme: theme);
+  }
+
+  void _updateSetting({ThemeMode? mode, GtTheme? theme}) {
+    final newSetting = GtThemeSetting(
+      mode: mode ?? _themeSetting.mode,
+      theme: theme ?? _themeSetting.theme,
+    );
+    if (newSetting == _themeSetting) return;
+    _themeSetting = newSetting;
+    notifyListeners();
+  }
+
+  void _observeTheme() {
+    _service.watchItem(AppStorageKey.themeName, (String? value) {
+      _updateSetting(theme: _resolveTheme(value));
+    });
+    _service.watchItem(AppStorageKey.themeMode, (String? value) {
+      _updateSetting(mode: _resolveMode(value));
+    });
+  }
+
+  ThemeMode _resolveMode(String? value) {
+    final mode = ThemeMode.values.tryFirstWhere(
+      (it) => it.name.equals(value ?? ''),
+    );
+    return mode ?? _themeSetting.mode;
+  }
+
+  GtTheme _resolveTheme(String? value) {
+    final theme = kAllThemes.tryFirstWhere((it) => it.name.equals(value ?? ''));
+    return theme ?? _themeSetting.theme;
+  }
+
+  Future<Map<String, String?>> _getStoredValues() async {
+    return _service.getItems([
+      AppStorageKey.themeMode,
+      AppStorageKey.themeName,
+    ]);
+  }
+
+  Future<void> changeMode(ThemeMode mode) async {
+    await _service.setItem(AppStorageKey.themeMode, mode.name);
+  }
+
+  Future<void> switchTheme(GtTheme theme) async {
+    await _service.setItem(AppStorageKey.themeName, theme.name);
+  }
+
+  @override
+  void dispose() {
+    _service.unWatchItems([AppStorageKey.themeMode, AppStorageKey.themeName]);
+    super.dispose();
+  }
+}

--- a/lib/common/state/state.dart
+++ b/lib/common/state/state.dart
@@ -1,0 +1,1 @@
+export 'gt_theme_state.dart';

--- a/lib/common/styling/gt_theme.dart
+++ b/lib/common/styling/gt_theme.dart
@@ -392,7 +392,7 @@ final kFlexTheme = GtTheme(
 /// The pre-configured theme for the Sterling Pro application.
 ///
 /// Uses `SterlingProLightPalette` and `SterlingProDarkPalette` for a premium, professional look.
-final kPProTheme = GtTheme(
+final kProTheme = GtTheme(
   lightPalette: SterlingProLightPalette(),
   darkPalette: SterlingProDarkPalette(),
   name: "Pro",
@@ -414,7 +414,7 @@ List<GtTheme> kAllThemes = [
   kPersonalTheme,
   kKidsTheme,
   kFlexTheme,
-  kPProTheme,
+  kProTheme,
   kGoTechTheme,
 ];
 

--- a/lib/common/utilities/extensions/gt_build_context_extension.dart
+++ b/lib/common/utilities/extensions/gt_build_context_extension.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/extensions/extensions.dart';
+import 'package:gt_mobile_foundation/utilities/app_logger.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:provider/provider.dart';
 
 /// An extension on [BuildContext] providing convenient access to the design system's
 /// theming, typography, sizing utilities, and responsive breakpoints.
@@ -69,8 +71,20 @@ extension ThemeContextExtension on BuildContext {
     return fracSizer.getShortestSideFraction(fraction);
   }
 
+  GtThemeState? get themeState {
+    try {
+      return read<GtThemeState>();
+    } catch (e, t) {
+      AppLogger.severe("$e", error: e, stackTrace: t);
+      return null;
+    }
+  }
+
   /// Checks if the current theme is dark mode.
-  bool get isInDarkMode => Theme.of(this).brightness == .dark;
+  bool get isInDarkMode {
+    final defualtValue = Theme.of(this).brightness == .dark;
+    return themeState?.isInDarkMode(this) ?? defualtValue;
+  }
 
   /// Retrieves the color palette defined in the current theme.
   GtPalette get palette =>

--- a/lib/widgets/molecules/inputs/gt_dob_field.dart
+++ b/lib/widgets/molecules/inputs/gt_dob_field.dart
@@ -102,8 +102,10 @@ class _GtDobFieldState extends State<GtDobField> with GtBottomSheetMixin {
               ],
             );
           },
-          initialValue: _dobController.dob,
-          validator: (value) {
+          onReset: _dobController.reset,
+          initialValue: _dobController,
+          validator: (controller) {
+            final value = controller?.dob;
             return AppValidators.dobValidator(
               value?.toIso8601String(),
               minAge: _dobController.minAge,

--- a/lib/widgets/molecules/inputs/gt_text_field.dart
+++ b/lib/widgets/molecules/inputs/gt_text_field.dart
@@ -200,6 +200,7 @@ class _GtTextFieldState extends State<GtTextField>
         listenable: Listenable.merge([_ctrl, _inputFocus]),
         builder: (context, child) {
           return FormField<TextEditingController>(
+            initialValue: _ctrl,
             validator: (value) {
               return widget.validator?.call(value?.text);
             },

--- a/lib/widgets/templates/state/gt_state_wrapper.dart
+++ b/lib/widgets/templates/state/gt_state_wrapper.dart
@@ -9,15 +9,15 @@ class GtStateWrapper extends GtStatelessWidget {
 
   const GtStateWrapper({
     super.key,
-    required this.child,
     required this.providers,
+    required this.child,
   }) : path = null;
 
   const GtStateWrapper.forPath({
     super.key,
-    required this.child,
     required this.providers,
     required String initialRoute,
+    required this.child,
   }) : path = initialRoute;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.32
+      ref: v0.0.33
   lottie: ^3.0.0
   pin_code_fields: ^9.3.0
   shimmer: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.33
+      ref: v0.0.34
   lottie: ^3.0.0
   pin_code_fields: ^9.3.0
   shimmer: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.30
+      ref: v0.0.32
   lottie: ^3.0.0
   pin_code_fields: ^9.3.0
   shimmer: ^3.0.0


### PR DESCRIPTION
## Description

- **Purpose:** Feature / Refactor
- **Issue Link:** N/A
- **Summary:** Implemented persistent theme state management using `GtThemeState` and `GtThemeSetting`. The gallery app has been updated to use this new state manager for persisting the selected theme. Added keychain sharing entitlements for macOS and iOS to ensure secure local storage functions correctly. Cleaned up outdated `gt_theme_addon.dart` logic in the gallery app.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [ ] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)

- N/A

## 🧪 How Has This Been Tested?

- [ ] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:* 1. Run the gallery app on macOS. 2. Change the theme. 3. Restart the app to verify the theme state persists correctly via keychain storage.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [ ] `flutter test` passes (all tests green).
- [ ] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
