### PR TITLE
feat: enhance GtDoubleColumnListTile with text style and line limits,…

### DIFF
--- a/gallery/lib/molecules/tiles/gt_list_tile.dart
+++ b/gallery/lib/molecules/tiles/gt_list_tile.dart
@@ -374,6 +374,15 @@ Widget gtListTileAllUseCase(BuildContext context) {
     GtCard(
       padding: context.insets.allDp(12.px),
       borderRadius: 12.circularBorderRadius,
+      child: GtDoubleColumnListTile(
+        context.knobs.string(label: "Label", initialValue: "Category"),
+        value: context.knobs.string(label: "Value", initialValue: "Bills"),
+      ),
+    ),
+    const GtGap.yBase(),
+    GtCard(
+      padding: context.insets.allDp(12.px),
+      borderRadius: 12.circularBorderRadius,
       child: Column(
         children: [
           GtDoubleColumnListTile(

--- a/lib/widgets/molecules/tiles/gt_info_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_info_tiles.dart
@@ -426,10 +426,22 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
   /// An optional widget displayed immediately after the [value].
   final Widget? valueSuffix;
 
+  ///Maximum number of lines for the label.
+  final int labelMaxLines;
+
+  ///Maximum number of lines for the value.
+  final int valueMaxLines;
+
   /// Whether to emphasize the [value] text over the [label].
   ///
   /// If true (default), the value uses a stronger style while the label is subtler.
   final bool highlightValue;
+
+  /// Optional custom [TextStyle] for the [value].
+  final TextStyle? valueTextStyle;
+
+  /// Optional custom [TextStyle] for the [label].
+  final TextStyle? labelTextStyle;
 
   /// Creates a [GtDoubleColumnListTile].
   const GtDoubleColumnListTile(
@@ -438,28 +450,61 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
     required this.value,
     this.valuePrefix,
     this.valueSuffix,
+    this.labelMaxLines = 1,
+    this.valueMaxLines = 2,
     this.highlightValue = true,
-  });
+    this.valueTextStyle,
+    this.labelTextStyle,
+  }) : assert(
+         highlightValue || (valueTextStyle == null && labelTextStyle == null),
+         'valueTextStyle and labelTextStyle must be null if highlightValue is false',
+       );
 
   @override
   Widget build(BuildContext context) {
-    final palette = context.palette;
+    final palette = context.palette.text;
     final textStyles = context.textStyles;
-    TextStyle labelStyle = textStyles.bodyS(color: palette.text.sub);
-    TextStyle valueStyle = textStyles.subHeadS();
+    TextStyle labelStyle =
+        labelTextStyle ?? textStyles.bodyS(color: palette.sub);
+    TextStyle valueStyle = valueTextStyle ?? textStyles.subHeadS();
 
     if (!highlightValue) {
-      labelStyle = labelStyle.copyWith(color: palette.text.strong);
-      valueStyle = valueStyle.copyWith(color: palette.text.soft);
+      labelStyle = labelStyle.copyWith(color: palette.strong);
+      valueStyle = valueStyle.copyWith(color: palette.soft);
     }
 
     return Row(
-      spacing: context.spacingBase,
+      spacing: context.spacingMd,
       children: [
-        Expanded(child: GtText(label, style: labelStyle)),
-        ?valuePrefix,
-        Text(value, style: valueStyle, textAlign: TextAlign.end),
-        ?valueSuffix,
+        Expanded(
+          flex: 4,
+          child: GtText(
+            label,
+            style: labelStyle,
+            maxLines: labelMaxLines,
+            overflow: .ellipsis,
+          ),
+        ),
+        Expanded(
+          flex: 5,
+          child: Row(
+            mainAxisAlignment: .end,
+            spacing: context.spacingBase,
+            children: [
+              ?valuePrefix,
+              Flexible(
+                child: GtText(
+                  value,
+                  style: valueStyle,
+                  textAlign: TextAlign.end,
+                  overflow: .ellipsis,
+                  maxLines: valueMaxLines,
+                ),
+              ),
+              ?valueSuffix,
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/lib/widgets/molecules/tiles/gt_info_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_info_tiles.dart
@@ -435,6 +435,9 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
   /// Whether to emphasize the [value] text over the [label].
   ///
   /// If true (default), the value uses a stronger style while the label is subtler.
+  @Deprecated(
+    'Use valueTextStyle and labelTextStyle instead, removalVersion: 1.0.0',
+  )
   final bool highlightValue;
 
   /// Optional custom [TextStyle] for the [value].
@@ -452,6 +455,7 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
     this.valueSuffix,
     this.labelMaxLines = 1,
     this.valueMaxLines = 2,
+    @Deprecated('Use valueTextStyle and labelTextStyle instead')
     this.highlightValue = true,
     this.valueTextStyle,
     this.labelTextStyle,

--- a/lib/widgets/organisms/view_state/gt_empty_state.dart
+++ b/lib/widgets/organisms/view_state/gt_empty_state.dart
@@ -41,7 +41,7 @@ class GtEmptyState extends GtStatelessWidget {
   /// Creates a [GtEmptyState] with required icon/title/subtitle content.
   const GtEmptyState({
     super.key,
-    required this.icon,
+    this.icon = const AppImageData(GtVectorIllustrations.empty),
     required this.title,
     this.subtitle,
     this.gapToSubtitle = const GtViewStateGapSpacer(GtGap.yMd()),

--- a/test/gt_mobile_ui_test.dart
+++ b/test/gt_mobile_ui_test.dart
@@ -1,1 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_ui/widgets/molecules/tiles/gt_info_tiles.dart';
 
+void main() {
+  group('GtDoubleColumnListTile assertions', () {
+    test('allows creation when highlightValue is true and styles are null', () {
+      expect(
+        () => GtDoubleColumnListTile(
+          'Label',
+          value: 'Value',
+          highlightValue: true,
+          valueTextStyle: null,
+          labelTextStyle: null,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('allows creation when highlightValue is true and styles are not null', () {
+      expect(
+        () => GtDoubleColumnListTile(
+          'Label',
+          value: 'Value',
+          highlightValue: true,
+          valueTextStyle: const TextStyle(fontSize: 12),
+          labelTextStyle: const TextStyle(fontSize: 12),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('allows creation when highlightValue is false and styles are null', () {
+      expect(
+        () => GtDoubleColumnListTile(
+          'Label',
+          value: 'Value',
+          highlightValue: false,
+          valueTextStyle: null,
+          labelTextStyle: null,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws AssertionError when highlightValue is false and valueTextStyle is not null', () {
+      expect(
+        () => GtDoubleColumnListTile(
+          'Label',
+          value: 'Value',
+          highlightValue: false,
+          valueTextStyle: const TextStyle(fontSize: 12),
+          labelTextStyle: null,
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('throws AssertionError when highlightValue is false and labelTextStyle is not null', () {
+      expect(
+        () => GtDoubleColumnListTile(
+          'Label',
+          value: 'Value',
+          highlightValue: false,
+          valueTextStyle: null,
+          labelTextStyle: const TextStyle(fontSize: 12),
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

- **Purpose:** Feature / Refactor
- **Issue Link:** [Link to Jira/GitHub Issue]
- **Summary:** Enforces style guidelines and enhances the usability of `GtDoubleColumnListTile` and `GtEmptyState`. 
  - Added an assertion to `GtDoubleColumnListTile` ensuring custom text styles are only allowed when `highlightValue` is set to `true`.
  - Added line limiting capabilities (`labelMaxLines` and `valueMaxLines`) and layout adjustments (using `Flexible` and `Row` alignment structures) to `GtDoubleColumnListTile`.
  - Allowed `GtEmptyState` to have a default illustration `GtVectorIllustrations.empty` for its `icon` property instead of requiring it.

## ✨ Type of Change

- [x] ✨ New Feature
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)


https://github.com/user-attachments/assets/8f82c849-c8a3-445b-a889-1fac29ffa379

<img width="441" height="967" alt="Screenshot 2026-07-13 at 14 48 25" src="https://github.com/user-attachments/assets/ffb8ec93-8440-4f1e-9437-7f32d08d01ca" />


## 🧪 How Has This Been Tested?

- [x] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated
- [ ] Manual Testing (Describe steps below)

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
