### PR TITLE
Implements FX Transfer Input support in `GtTransferField`

### DIFF
--- a/gallery/lib/main.directories.g.dart
+++ b/gallery/lib/main.directories.g.dart
@@ -817,6 +817,16 @@ final directories = <_widgetbook.WidgetbookNode>[
                 ],
               ),
               _widgetbook.WidgetbookComponent(
+                name: 'GtFxTransferField',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'GtFxTransferField',
+                    builder: _gallery_molecules_inputs_gt_transfer_field_usecase
+                        .playgroundGtFxTransferFieldUseCase,
+                  ),
+                ],
+              ),
+              _widgetbook.WidgetbookComponent(
                 name: 'GtPasswordField',
                 useCases: [
                   _widgetbook.WidgetbookUseCase(

--- a/gallery/lib/molecules/inputs/gt_amount_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_amount_field_usecase.dart
@@ -27,7 +27,7 @@ Widget playgroundGtAmountFieldUseCase(BuildContext context) {
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 

--- a/gallery/lib/molecules/inputs/gt_autocomplete_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_autocomplete_field_usecase.dart
@@ -7,16 +7,20 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 @widgetbook.UseCase(name: 'GtAutocompleteField', type: GtAutocompleteField)
 Widget playgroundGtAutocompleteFieldUseCase(BuildContext context) {
   final label = context.knobs.string(label: 'Label', initialValue: 'Fruit');
-  final hintText = context.knobs.string(label: 'Hint Text', initialValue: 'Type to search fruits...');
+  final hintText = context.knobs.string(
+    label: 'Hint Text',
+    initialValue: 'Type to search fruits...',
+  );
   final isEnabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 GtAutocompleteField<String>(
   controller: GtInputController(),
   suggestions: [
@@ -32,7 +36,8 @@ GtAutocompleteField<String>(
 
   return GtWidgetDocPage(
     title: 'GtAutocompleteField',
-    description: 'A text input field that provides a list of selectable suggestions as the user types.',
+    description:
+        'A text input field that provides a list of selectable suggestions as the user types.',
     code: codeSnippet,
     child: GtAutocompleteField<String>(
       controller: GtInputController(),

--- a/gallery/lib/molecules/inputs/gt_date_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_date_field_usecase.dart
@@ -6,13 +6,22 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 @widgetbook.UseCase(name: 'GtDateField', type: GtDateField)
 Widget playgroundGtDateFieldUseCase(BuildContext context) {
-  final label = context.knobs.string(label: 'Label', initialValue: 'Select date');
-  final calendarTitle = context.knobs.string(label: 'Calendar Title', initialValue: 'Pick a date');
-  final isRange = context.knobs.boolean(label: 'Range Picker Mode', initialValue: false);
+  final label = context.knobs.string(
+    label: 'Label',
+    initialValue: 'Select date',
+  );
+  final calendarTitle = context.knobs.string(
+    label: 'Calendar Title',
+    initialValue: 'Pick a date',
+  );
+  final isRange = context.knobs.boolean(
+    label: 'Range Picker Mode',
+    initialValue: false,
+  );
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 

--- a/gallery/lib/molecules/inputs/gt_dropdown_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_dropdown_field_usecase.dart
@@ -7,16 +7,20 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 @widgetbook.UseCase(name: 'GtDropdownField', type: GtDropdownField)
 Widget playgroundGtDropdownFieldUseCase(BuildContext context) {
   final label = context.knobs.string(label: 'Label', initialValue: 'Dropdown');
-  final sheetTitle = context.knobs.string(label: 'Sheet Title', initialValue: 'Select an Option');
+  final sheetTitle = context.knobs.string(
+    label: 'Sheet Title',
+    initialValue: 'Select an Option',
+  );
   final isEnabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 GtDropdownField<String>(
   controller: GtDropdownInputController(),
   options: const [
@@ -31,7 +35,8 @@ GtDropdownField<String>(
 
   return GtWidgetDocPage(
     title: 'GtDropdownField',
-    description: 'A text input field that provides a dropdown selection interface via a draggable bottom sheet.',
+    description:
+        'A text input field that provides a dropdown selection interface via a draggable bottom sheet.',
     code: codeSnippet,
     child: GtDropdownField<String>(
       controller: GtDropdownInputController(),

--- a/gallery/lib/molecules/inputs/gt_email_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_email_field_usecase.dart
@@ -6,17 +6,24 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 @widgetbook.UseCase(name: 'GtEmailField', type: GtEmailField)
 Widget playgroundGtEmailFieldUseCase(BuildContext context) {
-  final label = context.knobs.string(label: 'Label', initialValue: 'Email address');
+  final label = context.knobs.string(
+    label: 'Label',
+    initialValue: 'Email address',
+  );
   final isEnabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
-  final isRequired = context.knobs.boolean(label: 'Required', initialValue: true);
+  final isRequired = context.knobs.boolean(
+    label: 'Required',
+    initialValue: true,
+  );
   final decoration = context.knobs.object.dropdown(
     label: 'Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (d) => d.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 final _emailCtrl = GtInputController();
 
 GtEmailField(

--- a/gallery/lib/molecules/inputs/gt_inputs.dart
+++ b/gallery/lib/molecules/inputs/gt_inputs.dart
@@ -25,6 +25,8 @@ final _inputCtrl14 = GtDropdownInputController<Country>();
 final _inputCtrl15 = GtInputController<Country>();
 final _inputCtrl16 = GtInputController<Country>();
 final _formKey2 = GlobalKey<FormState>();
+final _fxSource = GtInputController();
+final _fxTarget = GtInputController();
 
 FutureOr<List<GtDropdownData<Country>>> get _allCountries async {
   final countries = await AppCountryUtility.fetchCountries();
@@ -71,7 +73,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: "Input Style",
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (value) => value.$1,
   );
   final helperText = context.knobs.stringOrNull(label: "Helper Text");
@@ -173,7 +175,7 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
               GtTransferField(
                 amountController: _inputCtrl8,
                 noteController: _inputCtrl9,
-                participantSeparator: GtSvg(GtVectors.moveMoney),
+                middleIcon: GtSvg(GtVectors.moveMoney),
                 min: 400,
                 max: 1000,
                 firstParticipant: GtTransferParticipantData(
@@ -187,6 +189,62 @@ Widget buildGtTextFieldUsecase(BuildContext context) {
                 ),
                 secondParticipant: GtTransferParticipantData.empty(label: "to"),
                 noteHint: "Add a note (optional)",
+              ),
+              const GtGap.yXl(),
+              GtFxTransferField(
+                sourceAmountController: _fxSource,
+                targetAmountController: _fxTarget,
+                onSourceAmountChanged: (value) {
+                  if (!value.hasValue) {
+                    _fxTarget.clear();
+                    return;
+                  }
+
+                  final amount = (value.asAmount ?? 0) * 1350;
+                  _fxTarget.text = amount.formattedNumberLong;
+                },
+                onTargetAmountChanged: (value) {
+                  if (!value.hasValue) {
+                    _fxSource.clear();
+                    return;
+                  }
+
+                  final amount = (value.asAmount ?? 0) / 1350;
+                  _fxSource.text = amount.formattedNumberLong;
+                },
+                noteController: GtInputController(),
+                firstParticipant: GtTransferParticipantData(
+                  label: "from",
+                  image: AppImageData(GtNetworkImages.business),
+                  imageType: .image,
+                  validate: true,
+                  name: "usd account · 1020293939",
+                  balance: 200015,
+                  currency: AppStrings.dollar,
+                ),
+                secondParticipant: GtTransferParticipantData(
+                  label: "to",
+                  image: AppImageData(GtNetworkImages.sampleAvatar1),
+                  validate: false,
+                  name: "Dubai Trip",
+                  balance: 1000000000,
+                  currency: AppStrings.naira,
+                ),
+                noteHint: "Add a note (optional)",
+                child: Text.rich(
+                  TextSpan(
+                    text: "Live exchange rate: ",
+                    children: [
+                      TextSpan(
+                        text: "\$1 = ${1350.asCurrency()}",
+                        style: context.textStyles.subHeadXs(
+                          color: context.palette.primary.dark,
+                        ),
+                      ),
+                    ],
+                  ),
+                  style: context.textStyles.subHeadXs(),
+                ),
               ),
               const GtGap.yXl(),
               GtDateField(

--- a/gallery/lib/molecules/inputs/gt_password_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_password_field_usecase.dart
@@ -8,15 +8,21 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 Widget playgroundGtPasswordFieldUseCase(BuildContext context) {
   final label = context.knobs.string(label: 'Label', initialValue: 'Password');
   final isEnabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
-  final minLength = context.knobs.int.slider(label: 'Min Length', initialValue: 6, min: 3, max: 12);
+  final minLength = context.knobs.int.slider(
+    label: 'Min Length',
+    initialValue: 6,
+    min: 3,
+    max: 12,
+  );
   final decoration = context.knobs.object.dropdown(
     label: 'Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (d) => d.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 final _passCtrl = GtInputController();
 
 GtPasswordField(

--- a/gallery/lib/molecules/inputs/gt_phone_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_phone_field_usecase.dart
@@ -6,18 +6,28 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 @widgetbook.UseCase(name: 'GtPhoneField', type: GtPhoneField)
 Widget playgroundGtPhoneFieldUseCase(BuildContext context) {
-  final label = context.knobs.string(label: 'Label', initialValue: 'Phone number');
-  final showCountryCode = context.knobs.boolean(label: 'Show Country Code', initialValue: true);
+  final label = context.knobs.string(
+    label: 'Label',
+    initialValue: 'Phone number',
+  );
+  final showCountryCode = context.knobs.boolean(
+    label: 'Show Country Code',
+    initialValue: true,
+  );
   final isEnabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
-  final isRequired = context.knobs.boolean(label: 'Required', initialValue: true);
+  final isRequired = context.knobs.boolean(
+    label: 'Required',
+    initialValue: true,
+  );
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 GtPhoneField(
   label: '$label',
   showCountryCode: $showCountryCode,

--- a/gallery/lib/molecules/inputs/gt_search_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_search_field_usecase.dart
@@ -6,19 +6,32 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 @widgetbook.UseCase(name: 'GtSearchField', type: GtSearchField)
 Widget playgroundGtSearchFieldUseCase(BuildContext context) {
-  final hintText = context.knobs.string(label: "Hint Text", initialValue: "Search here...");
-  final autoFocus = context.knobs.boolean(label: "Auto Focus", initialValue: true);
+  final hintText = context.knobs.string(
+    label: "Hint Text",
+    initialValue: "Search here...",
+  );
+  final autoFocus = context.knobs.boolean(
+    label: "Auto Focus",
+    initialValue: true,
+  );
   final isEnabled = context.knobs.boolean(label: "Enabled", initialValue: true);
-  final isRequired = context.knobs.boolean(label: "Required", initialValue: true);
-  final helperText = context.knobs.string(label: "Helper Text", initialValue: "");
+  final isRequired = context.knobs.boolean(
+    label: "Required",
+    initialValue: true,
+  );
+  final helperText = context.knobs.string(
+    label: "Helper Text",
+    initialValue: "",
+  );
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 GtSearchField(
   controller: GtInputController(),
   hintText: "$hintText",
@@ -31,7 +44,8 @@ GtSearchField(
 
   return GtWidgetDocPage(
     title: 'GtSearchField',
-    description: 'A specialized text input field designed specifically for search functionality.',
+    description:
+        'A specialized text input field designed specifically for search functionality.',
     code: codeSnippet,
     child: GtSearchField(
       controller: GtInputController(),

--- a/gallery/lib/molecules/inputs/gt_text_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_text_field_usecase.dart
@@ -7,16 +7,20 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 @widgetbook.UseCase(name: 'GtTextField', type: GtTextField)
 Widget playgroundGtTextFieldUseCase(BuildContext context) {
   final label = context.knobs.string(label: 'Label', initialValue: 'Name');
-  final hintText = context.knobs.string(label: 'Hint Text', initialValue: 'Enter your name');
+  final hintText = context.knobs.string(
+    label: 'Hint Text',
+    initialValue: 'Enter your name',
+  );
   final isEnabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 GtTextField(
   controller: GtInputController(),
   label: "$label",
@@ -27,7 +31,8 @@ GtTextField(
 
   return GtWidgetDocPage(
     title: 'GtTextField',
-    description: 'A customizable text input field conforming to the design system styling.',
+    description:
+        'A customizable text input field conforming to the design system styling.',
     code: codeSnippet,
     child: GtTextField(
       controller: GtInputController(),

--- a/gallery/lib/molecules/inputs/gt_transfer_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_transfer_field_usecase.dart
@@ -17,13 +17,13 @@ GtTransferField(
     label: "from",
     image: AppImageData(GtNetworkImages.savings),
     validate: true,
-    data: "My Account"
+    name: "My Account",
   ),
   secondParticipant: GtTransferParticipantData(
     label: "to",
     image: AppImageData(GtNetworkImages.sampleAvatar1),
     validate: false,
-    data: "Savings Account"
+    name: "Savings Account",
   ),
   noteHint: "What is this for?",
 )
@@ -35,15 +35,147 @@ GtTransferField(
         label: "from",
         image: AppImageData(GtNetworkImages.savings),
         validate: true,
-        data: "My Account"
+        name: "My Account",
       ),
       secondParticipant: GtTransferParticipantData(
         label: "to",
         image: AppImageData(GtNetworkImages.sampleAvatar1),
         validate: false,
-        data: "Savings Account"
+        name: "Savings Account",
       ),
       noteHint: "What is this for?",
+    ),
+  );
+}
+
+GtInputController source = GtInputController();
+GtInputController target = GtInputController();
+
+@widgetbook.UseCase(name: 'GtFxTransferField', type: GtFxTransferField)
+Widget playgroundGtFxTransferFieldUseCase(BuildContext context) {
+  return GtWidgetDocPage(
+    title: 'GtFxTransferField',
+    description: 'Documentation for GtFxTransferField',
+    code:
+        '''
+GtFxTransferField(
+  sourceAmountController: source,
+  targetAmountController: target,
+  onSourceAmountChanged: (value) {
+    AppDebouncer(300.milliseconds).run(() {
+      if (!value.hasValue) {
+        target.clear();
+        return;
+      }
+
+      final amount = (value.asAmount ?? 0) * 1350;
+      target.text = amount.formattedNumberLong;
+    });
+  },
+  onTargetAmountChanged: (value) {
+    AppDebouncer(300.milliseconds).run(() {
+      if (!value.hasValue) {
+        source.clear();
+        return;
+      }
+
+      final amount = (value.asAmount ?? 0) / 1350;
+      source.text = amount.formattedNumberLong;
+    });
+  },
+  noteController: GtInputController(),
+  firstParticipant: GtTransferParticipantData(
+    label: "from",
+    image: AppImageData(GtNetworkImages.business),
+    imageType: .image,
+    validate: true,
+    name: "usd account · 1020293939",
+    balance: 200015,
+    currency: AppStrings.dollar,
+  ),
+  secondParticipant: GtTransferParticipantData(
+    label: "to",
+    image: AppImageData(GtNetworkImages.sampleAvatar1),
+    validate: false,
+    name: "Dubai Trip",
+    balance: 1000000000,
+    currency: AppStrings.naira,
+  ),
+  noteHint: "Add a note (optional)",
+  child: Text.rich(
+    TextSpan(
+      text: "Live exchange rate: ",
+      children: [
+        TextSpan(
+          text: "\$1 = ${1350.asCurrency()}",
+          style: context.textStyles.subHeadXs(
+            color: context.palette.primary.dark,
+          ),
+        ),
+      ],
+    ),
+    style: context.textStyles.subHeadXs(),
+  ),
+)
+''',
+    child: GtFxTransferField(
+      sourceAmountController: source,
+      targetAmountController: target,
+      onSourceAmountChanged: (value) {
+        AppDebouncer(300.milliseconds).run(() {
+          if (!value.hasValue) {
+            target.clear();
+            return;
+          }
+
+          final amount = (value.asAmount ?? 0) * 1350;
+          target.text = amount.formattedNumberLong;
+        });
+      },
+      onTargetAmountChanged: (value) {
+        AppDebouncer(300.milliseconds).run(() {
+          if (!value.hasValue) {
+            source.clear();
+            return;
+          }
+
+          final amount = (value.asAmount ?? 0) / 1350;
+          source.text = amount.formattedNumberLong;
+        });
+      },
+      noteController: GtInputController(),
+      firstParticipant: GtTransferParticipantData(
+        label: "from",
+        image: AppImageData(GtNetworkImages.business),
+        imageType: .image,
+        validate: true,
+        name: "usd account · 1020293939",
+        balance: 200015,
+        currency: AppStrings.dollar,
+      ),
+      secondParticipant: GtTransferParticipantData(
+        label: "to",
+        image: AppImageData(GtNetworkImages.sampleAvatar1),
+        validate: false,
+        name: "Dubai Trip",
+        balance: 1000000000,
+        currency: AppStrings.naira,
+      ),
+      noteHint: "Add a note (optional)",
+      child: Text.rich(
+        TextSpan(
+          text: "Live exchange rate: ",
+          children: [
+            TextSpan(
+              text: "\$1 = ${1350.asCurrency()}",
+              style: context.textStyles.subHeadXs(
+                color: context.palette.primary.dark,
+              ),
+            ),
+          ],
+        ),
+        style: context.textStyles.subHeadXs(),
+      ),
     ),
   );
 }

--- a/gallery/lib/molecules/inputs/gt_url_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_url_field_usecase.dart
@@ -11,11 +11,12 @@ Widget playgroundGtUrlFieldUseCase(BuildContext context) {
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all[1],
+    initialOption: context.inputStyles.all.first,
     labelBuilder: (v) => v.$1,
   );
 
-  final codeSnippet = '''
+  final codeSnippet =
+      '''
 GtUrlField(
   controller: GtInputController(),
   label: "$label",
@@ -25,7 +26,8 @@ GtUrlField(
 
   return GtWidgetDocPage(
     title: 'GtUrlField',
-    description: 'A text field specialized for entering URLs with standard URL format validation.',
+    description:
+        'A text field specialized for entering URLs with standard URL format validation.',
     code: codeSnippet,
     child: GtUrlField(
       controller: GtInputController(),

--- a/gallery/lib/organisms/grids/gt_grids.dart
+++ b/gallery/lib/organisms/grids/gt_grids.dart
@@ -3,7 +3,7 @@ import 'package:gallery/lib.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
-final _categoryCtrl = GtTransferCategoryController(null);
+final _categoryCtrl = GtTransactionCategoryController(null, categories: []);
 
 @widgetbook.UseCase(
   name: 'GtTransferCategoryGrid',
@@ -12,7 +12,8 @@ final _categoryCtrl = GtTransferCategoryController(null);
 Widget buildGtTransferCategoryGridUsecase(BuildContext context) {
   return GtWidgetDocPage(
     title: 'GtTransferCategoryGrid',
-    description: 'A structured grid layout designed for choosing transaction categories.',
+    description:
+        'A structured grid layout designed for choosing transaction categories.',
     code: '''
 GtTransferCategoryGrid(
   controller: categoryController,
@@ -22,10 +23,7 @@ GtTransferCategoryGrid(
       child: GtCard(
         padding: context.insets.allDp(12.px),
         variant: GtCardVariant.normal,
-        child: GtTransferCategoryGrid(
-          controller: _categoryCtrl,
-          onAdd: () {},
-        ),
+        child: GtTransferCategoryGrid(controller: _categoryCtrl, onAdd: () {}),
       ),
     ),
   );

--- a/lib/common/data/gt_transaction_category.dart
+++ b/lib/common/data/gt_transaction_category.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
@@ -22,6 +23,10 @@ class GtTransactionCategory {
     this.variant,
   });
 
+  GtDropdownData<GtTransactionCategory> get dropdownData {
+    return GtDropdownData(value: this, label: label);
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -33,4 +38,226 @@ class GtTransactionCategory {
 
   @override
   int get hashCode => Object.hash(label, image, variant);
+}
+
+/// A controller that manages the selection state of a [GtTransactionCategory].
+///
+/// It extends [ValueNotifier] to allow widgets to rebuild when the selected
+/// category changes.
+class GtTransactionCategoryController
+    extends ValueNotifier<GtTransactionCategory?> {
+  List<GtTransactionCategory> _categories;
+
+  /// Creates a [GtTransactionCategoryController] with an initial [value].
+  GtTransactionCategoryController(
+    super.value, {
+    required List<GtTransactionCategory> categories,
+  }) : _categories = categories;
+
+  /// Updates the currently selected category to the provided [category].
+  void select(GtTransactionCategory category) {
+    value = category;
+  }
+
+  set categories(List<GtTransactionCategory> categories) {
+    _categories = categories;
+    notifyListeners();
+  }
+
+  /// Gets the list of all available categories.
+  List<GtTransactionCategory> get categories => .unmodifiable(_categories);
+
+  /// Resets the selected category to null.
+  void reset() => value = null;
+
+  @override
+  void dispose() {
+    _categories.clear();
+    super.dispose();
+  }
+}
+
+/// A mixin that provides a comprehensive list of default transaction categories.
+///
+/// These categories are commonly used in financial applications for classifying
+/// transfers, payments, and other transactions.
+mixin GtTransactionCategoryMixin {
+  /// A predefined list of standard [GtTransactionCategory] objects.
+  List<GtTransactionCategory> get defaultGridCategories => [
+    GtTransactionCategory(
+      label: "transfers".ctr(),
+      image: AppImageData(GtNetworkImages.transfer),
+      variant: .info,
+    ),
+    GtTransactionCategory(
+      label: "shopping".ctr(),
+      image: AppImageData(GtNetworkImages.shopping),
+      variant: .featured,
+    ),
+    GtTransactionCategory(
+      label: "payroll".ctr(),
+      image: AppImageData(GtNetworkImages.cash),
+      variant: .success,
+    ),
+    GtTransactionCategory(
+      label: "family".ctr(),
+      image: AppImageData(GtNetworkImages.family),
+      variant: .info,
+    ),
+    GtTransactionCategory(
+      label: "food".ctr(),
+      image: AppImageData(GtNetworkImages.food),
+      variant: .error,
+    ),
+    GtTransactionCategory(
+      label: "savings".ctr(),
+      image: AppImageData(GtNetworkImages.savings),
+      variant: .success,
+    ),
+    GtTransactionCategory(
+      label: "bills".ctr(),
+      image: AppImageData(GtNetworkImages.bill),
+      variant: .error,
+    ),
+    GtTransactionCategory(
+      label: "card".ctr(),
+      image: AppImageData(GtNetworkImages.card),
+      variant: .success,
+    ),
+    GtTransactionCategory(
+      label: "household".ctr(),
+      image: AppImageData(GtNetworkImages.household),
+      variant: .info,
+    ),
+    GtTransactionCategory(
+      label: "health".ctr(),
+      image: AppImageData(GtNetworkImages.health),
+      variant: .error,
+    ),
+    GtTransactionCategory(
+      label: "gift".ctr(),
+      image: AppImageData(GtNetworkImages.gift),
+      variant: .featured,
+    ),
+    GtTransactionCategory(
+      label: "charity".ctr(),
+      image: AppImageData(GtNetworkImages.charity),
+      variant: .success,
+    ),
+    GtTransactionCategory(
+      label: "holiday".ctr(),
+      image: AppImageData(GtNetworkImages.holiday),
+      variant: .featured,
+    ),
+    GtTransactionCategory(
+      label: "transport".ctr(),
+      image: AppImageData(GtNetworkImages.transport),
+      variant: .info,
+    ),
+    GtTransactionCategory(
+      label: "education".ctr(),
+      image: AppImageData(GtNetworkImages.school),
+      variant: .success,
+    ),
+    GtTransactionCategory(
+      label: "emergency".ctr(),
+      image: AppImageData(GtNetworkImages.alarm),
+      variant: .error,
+    ),
+    GtTransactionCategory(
+      label: "refund".ctr(),
+      image: AppImageData(GtNetworkImages.returns),
+      variant: .error,
+    ),
+    GtTransactionCategory(
+      label: "books".ctr(),
+      image: AppImageData(GtNetworkImages.books),
+      variant: .featured,
+    ),
+    GtTransactionCategory(
+      label: "fitness".ctr(),
+      image: AppImageData(GtNetworkImages.gym),
+      variant: .success,
+    ),
+  ];
+
+  /// A predefined list of standard [GtTransactionCategory] objects.
+  List<GtTransactionCategory> get defaultInputCategories => [
+    GtTransactionCategory(
+      label: "transfers".ctr(),
+      image: AppImageData(GtVectorIllustrations.transferCat),
+    ),
+    GtTransactionCategory(
+      label: "shopping".ctr(),
+      image: AppImageData(GtVectorIllustrations.shoppingCat),
+    ),
+    GtTransactionCategory(
+      label: "payroll".ctr(),
+      image: AppImageData(GtVectorIllustrations.payrollCat),
+    ),
+    GtTransactionCategory(
+      label: "family".ctr(),
+      image: AppImageData(GtVectorIllustrations.familyCat),
+    ),
+    GtTransactionCategory(
+      label: "food".ctr(),
+      image: AppImageData(GtVectorIllustrations.foodCat),
+    ),
+    GtTransactionCategory(
+      label: "savings".ctr(),
+      image: AppImageData(GtVectorIllustrations.savingsCat),
+    ),
+    GtTransactionCategory(
+      label: "bills".ctr(),
+      image: AppImageData(GtVectorIllustrations.cashCat),
+    ),
+    GtTransactionCategory(
+      label: "card".ctr(),
+      image: AppImageData(GtVectorIllustrations.debitCardsCat),
+    ),
+    GtTransactionCategory(
+      label: "household".ctr(),
+      image: AppImageData(GtVectorIllustrations.houseCat),
+    ),
+    GtTransactionCategory(
+      label: "health".ctr(),
+      image: AppImageData(GtVectorIllustrations.healthCat),
+    ),
+    GtTransactionCategory(
+      label: "gift".ctr(),
+      image: AppImageData(GtVectorIllustrations.giftCat),
+    ),
+    GtTransactionCategory(
+      label: "charity".ctr(),
+      image: AppImageData(GtVectorIllustrations.charityCat),
+    ),
+    GtTransactionCategory(
+      label: "holiday".ctr(),
+      image: AppImageData(GtVectorIllustrations.holidayCat),
+    ),
+    GtTransactionCategory(
+      label: "transport".ctr(),
+      image: AppImageData(GtVectorIllustrations.transportCat),
+    ),
+    GtTransactionCategory(
+      label: "education".ctr(),
+      image: AppImageData(GtVectorIllustrations.educationCat),
+    ),
+    GtTransactionCategory(
+      label: "emergency".ctr(),
+      image: AppImageData(GtVectorIllustrations.emergencyCat),
+    ),
+    GtTransactionCategory(
+      label: "refund".ctr(),
+      image: AppImageData(GtVectorIllustrations.detailsCat),
+    ),
+    GtTransactionCategory(
+      label: "books".ctr(),
+      image: AppImageData(GtVectorIllustrations.file),
+    ),
+    GtTransactionCategory(
+      label: "fitness".ctr(),
+      image: AppImageData(GtVectorIllustrations.fitnessCat),
+    ),
+  ];
 }

--- a/lib/common/styling/gt_input_styles.dart
+++ b/lib/common/styling/gt_input_styles.dart
@@ -80,6 +80,25 @@ class GtInputStyles {
     );
   }
 
+  /// The style configuration used for large, emphasis-heavy inputs,
+  /// typically seen in money transfer screens.
+  GtInputDecoration get fxTransferInputStyle {
+    final textStyle = context.textStyles.fxInput();
+    final disabledStyle = textStyle.copyWith(
+      color: context.palette.text.disabled,
+    );
+    return GtInputDecoration(
+      size: Size(.infinity, 48),
+      textStyle: textStyle,
+      disabledStyle: disabledStyle,
+      hintStyle: disabledStyle,
+      errorStyle: context.textStyles.body2s(color: context.palette.error.base),
+      helperStyle: context.textStyles.body2s(),
+      decoration: BoxDecoration(),
+      padding: context.insets.allDp(8.px),
+    );
+  }
+
   /// The default style configuration for standard form text fields,
   /// featuring a weak background and standard height.
   GtInputDecoration get defaultDecoration {
@@ -396,8 +415,9 @@ class GtInputStyles {
 
   /// A collection containing all predefined [GtInputDecoration] configurations paired with their labels.
   List<(String, GtInputDecoration)> get all => [
-    ('Transfer Input Style', transferInputStyle),
     ('Default Decoration', defaultDecoration),
+    ('Transfer Input Style', transferInputStyle),
+    ('FX Transfer Input Style', fxTransferInputStyle),
     ('Plain Decoration', plainDecoration),
     ('Small Decoration', smDecoration),
     ('Search Decoration', searchDecoration),

--- a/lib/common/styling/gt_text_styles.dart
+++ b/lib/common/styling/gt_text_styles.dart
@@ -1289,6 +1289,31 @@ class GtTextStyles {
     );
   }
 
+  /// Generates the text style used for calendar days and headers.
+  TextStyle fxInput({
+    double? heightPx,
+    Color? color,
+    TextDecoration? decoration,
+    Color? decorationColor,
+    double? decorationThickness,
+    TextDecorationStyle? decorationStyle,
+    TextOverflow? overflow,
+  }) {
+    return _buildStyle(
+      family: fonts.title,
+      size: 28,
+      heightPx: heightPx ?? 32,
+      widthPct: 0,
+      weight: FontWeight.bold,
+      color: color,
+      decoration: decoration,
+      decorationColor: decorationColor,
+      decorationThickness: decorationThickness,
+      decorationStyle: decorationStyle,
+      overflow: overflow,
+    );
+  }
+
   /// A collection containing all predefined [TextStyle] configurations paired with their labels.
   List<(String, TextStyle)> get all => [
     ('Display 1 (context.textStyles.d1)', d1()),
@@ -1334,5 +1359,6 @@ class GtTextStyles {
     ('Button XXS (context.textStyles.buttonXxs)', buttonXxs()),
     ('Nav Bar Label (context.textStyles.navBarLabel)', navBarLabel()),
     ('Calendar (context.textStyles.calendar)', calendar()),
+    ('FX Input (context.textStyles.fxInput)', fxInput()),
   ];
 }

--- a/lib/widgets/molecules/inputs/gt_drowpdown_field.dart
+++ b/lib/widgets/molecules/inputs/gt_drowpdown_field.dart
@@ -229,7 +229,7 @@ class GtDropDownModal<T> extends GtStatefulWidget {
   final bool autoFocus;
 
   /// An optional builder for individual option list tiles.
-  final ValueBuilder2<GtDropdownData, GtDropdownInputController>? builder;
+  final ValueBuilder2<GtDropdownData<T>, GtDropdownInputController>? builder;
 
   /// An optional builder to completely override the list rendering.
   final ValueBuilder3<
@@ -263,7 +263,7 @@ class GtDropDownModal<T> extends GtStatefulWidget {
   State<GtDropDownModal> createState() => _GtDropDownModalState<T>();
 }
 
-class _GtDropDownModalState<T> extends State<GtDropDownModal>
+class _GtDropDownModalState<T> extends State<GtDropDownModal<T>>
     with AppTaskMixin {
   late final AppDebouncer debouncer;
   List<GtDropdownData<T>> options = [];
@@ -287,7 +287,7 @@ class _GtDropDownModalState<T> extends State<GtDropDownModal>
 
   Future<List<GtDropdownData<T>>> _getOptions() async {
     final data = await tryRunThrowableTask(() async => await widget.options);
-    options = (data ?? []) as List<GtDropdownData<T>>;
+    options = data ?? [];
     presentedOptions.value = options;
     return options;
   }

--- a/lib/widgets/molecules/inputs/gt_transfer_field.dart
+++ b/lib/widgets/molecules/inputs/gt_transfer_field.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -16,11 +17,20 @@ class GtTransferField extends GtStatefulWidget {
   /// The controller used to read and manipulate the note or description input.
   final GtInputController noteController;
 
+  /// The controller that manages the category of the transfer.
+  final GtTransactionCategoryController? categoryController;
+
   /// The hint text displayed inside the note input field.
   final String noteHint;
 
-  /// Callback invoked whenever either the amount or the note changes.
-  final OnChanged<({String? amount, String? note})>? onChange;
+  /// Callback invoked whenever the amount changes.
+  final OnChanged<String?>? onAmountChanged;
+
+  /// Callback invoked whenever the note changes.
+  final OnChanged<String?>? onNoteChanged;
+
+  /// Callback invoked whenever the category changes.
+  final OnChanged<GtTransactionCategory?>? onCategoryChanged;
 
   /// Whether the transfer field is interactive and can be modified. Defaults to true.
   final bool isEnabled;
@@ -31,9 +41,13 @@ class GtTransferField extends GtStatefulWidget {
   /// The maximum allowable amount for the transfer.
   final num? max;
 
-  final Widget? participantSeparator;
+  /// The icon to display between the two participants.
+  final Widget? middleIcon;
 
+  /// The first participant in the transfer.
   final GtTransferParticipantData firstParticipant;
+
+  /// The second participant in the transfer.
   final GtTransferParticipantData secondParticipant;
 
   /// Creates a new [GtTransferField].
@@ -44,11 +58,14 @@ class GtTransferField extends GtStatefulWidget {
     required this.firstParticipant,
     required this.secondParticipant,
     required this.noteHint,
-    this.onChange,
+    this.categoryController,
+    this.onAmountChanged,
+    this.onNoteChanged,
+    this.onCategoryChanged,
     this.isEnabled = true,
     this.max,
     this.min,
-    this.participantSeparator,
+    this.middleIcon,
   });
 
   @override
@@ -112,12 +129,7 @@ class _GtTransferFieldState extends State<GtTransferField> {
           controller: widget.amountController,
           textAlign: .end,
           keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          onChanged: (value) {
-            widget.onChange?.call((
-              amount: value,
-              note: widget.noteController.text,
-            ));
-          },
+          onChanged: widget.onAmountChanged,
           autofillHints: const [AutofillHints.transactionAmount],
           autoCorrect: false,
         );
@@ -155,7 +167,7 @@ class _GtTransferFieldState extends State<GtTransferField> {
                               color: context.palette.stroke.soft,
                             ),
                             child: Center(
-                              child: widget.participantSeparator ?? separator,
+                              child: widget.middleIcon ?? separator,
                             ),
                           ),
                         ),
@@ -188,22 +200,277 @@ class _GtTransferFieldState extends State<GtTransferField> {
                 ),
               ),
             ),
-            GtTextField(
-              controller: widget.noteController,
-              hintText: widget.noteHint,
-              isEnabled: widget.isEnabled,
-              decoration: context.inputStyles.plainDecoration,
-              suffix: GtNetworkImage(
-                GtNetworkImages.transfer,
-                height: context.dp(32.px),
-                width: context.dp(32.px),
+            GtTransferCategoryField(
+              controller: widget.categoryController,
+              onChanged: widget.onCategoryChanged,
+              leading: GtTextField(
+                controller: widget.noteController,
+                hintText: widget.noteHint,
+                isEnabled: widget.isEnabled,
+                decoration: context.inputStyles.plainDecoration,
+                onChanged: widget.onNoteChanged,
               ),
-              onChanged: (value) {
-                widget.onChange?.call((
-                  amount: widget.amountController.text,
-                  note: value,
-                ));
-              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// A specialized compound input field designed for FX money transfer screens.
+class GtFxTransferField extends GtStatefulWidget {
+  /// The controller for the source amount input field.
+  final GtInputController sourceAmountController;
+
+  /// The controller for the target amount input field.
+  final GtInputController targetAmountController;
+
+  /// The controller for the note input field.
+  final GtInputController noteController;
+
+  /// The controller that manages the category of the transfer.
+  final GtTransactionCategoryController? categoryController;
+
+  /// The hint text displayed inside the note input field.
+  final String noteHint;
+
+  /// Callback invoked whenever the source amount changes.
+  final OnChanged<String?>? onSourceAmountChanged;
+
+  /// Callback invoked whenever the target amount changes.
+  final OnChanged<String?>? onTargetAmountChanged;
+
+  /// Callback invoked whenever the note changes.
+  final OnChanged<String?>? onNoteChanged;
+
+  /// Callback invoked whenever the category changes.
+  final OnChanged<GtTransactionCategory?>? onCategoryChanged;
+
+  /// Whether the transfer field is interactive and can be modified. Defaults to true.
+  final bool isEnabled;
+
+  /// The minimum allowable amount for the transfer.
+  final num? min;
+
+  /// The maximum allowable amount for the transfer.
+  final num? max;
+
+  /// The icon to display between the two participants.
+  final Widget? middleIcon;
+
+  /// The first participant in the transfer.
+  final GtTransferParticipantData firstParticipant;
+
+  /// The second participant in the transfer.
+  final GtTransferParticipantData secondParticipant;
+
+  /// The content to display between the two participants.
+  final Widget? child;
+
+  /// Creates a new [GtTransferField].
+  const GtFxTransferField({
+    super.key,
+    required this.sourceAmountController,
+    required this.targetAmountController,
+    required this.noteController,
+    required this.firstParticipant,
+    required this.secondParticipant,
+    required this.noteHint,
+    this.categoryController,
+    this.onCategoryChanged,
+    this.onSourceAmountChanged,
+    this.onTargetAmountChanged,
+    this.onNoteChanged,
+    this.isEnabled = true,
+    this.max,
+    this.min,
+    this.middleIcon,
+    this.child,
+  });
+
+  @override
+  State<GtFxTransferField> createState() => _GtFxTransferFieldState();
+}
+
+class _GtFxTransferFieldState extends State<GtFxTransferField> {
+  double get balance {
+    final first = widget.firstParticipant;
+    final second = widget.secondParticipant;
+    double? value;
+
+    if (first.validate) value = first.balance;
+    if (second.validate) value = second.balance;
+
+    return value ?? 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final first = widget.firstParticipant;
+    final second = widget.secondParticipant;
+    final separator = GtSvg(GtVectors.trendDown, width: context.dp(20.px));
+
+    return FormField(
+      initialValue: widget.sourceAmountController.controller,
+      validator: (text) {
+        if (widget.min != null || widget.max != null) {
+          return AppValidators.amountValidator(
+            text?.text,
+            minAmount: widget.min,
+            maxAmount: min(balance, widget.max ?? 0),
+          );
+        }
+        return AppValidators.balanceValidator(
+          widget.sourceAmountController.text,
+          balance: balance,
+        );
+      },
+      builder: (field) {
+        GtInputDecoration decoration = context.inputStyles.fxTransferInputStyle;
+        String? footer;
+        TextStyle? subStyle;
+
+        if (field.hasError) {
+          footer = field.errorText;
+          subStyle = decoration.errorStyle;
+          decoration = decoration.copyWith(
+            textStyle: decoration.textStyle.copyWith(
+              color: context.palette.error.base,
+            ),
+          );
+        }
+
+        final sourceField = GtTextField(
+          key: PageStorageKey("$balance-${first.label}-${second.label}"),
+          decoration: decoration,
+          isEnabled: widget.isEnabled,
+          hintText: "0.00",
+          inputFormatters: [AppAmountFormatter()],
+          controller: widget.sourceAmountController,
+          textAlign: .end,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          onChanged: widget.onSourceAmountChanged,
+          autofillHints: const [AutofillHints.transactionAmount],
+          autoCorrect: false,
+        );
+
+        final targetField = GtTextField(
+          key: PageStorageKey("$balance-${first.label}-${second.label}"),
+          decoration: decoration,
+          isEnabled: widget.isEnabled,
+          hintText: "0.00",
+          inputFormatters: [AppAmountFormatter()],
+          controller: widget.targetAmountController,
+          textAlign: .end,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          onChanged: widget.onTargetAmountChanged,
+          autofillHints: const [AutofillHints.transactionAmount],
+          autoCorrect: false,
+        );
+
+        return Column(
+          crossAxisAlignment: .stretch,
+          children: [
+            GtCard(
+              padding: context.insets.symmetricDp(
+                vertical: 16.px,
+                horizontal: 12.px,
+              ),
+              child: Column(
+                mainAxisAlignment: .center,
+                crossAxisAlignment: .stretch,
+                children: [
+                  Row(
+                    spacing: context.spacingSm,
+                    children: [
+                      Expanded(
+                        flex: 6,
+                        child: _GtTransferParticipantWidget(
+                          key: ValueKey(first.label),
+                          data: first,
+                          footerSuffix: first.validate ? footer : null,
+                          footerStyle: first.validate ? subStyle : null,
+                          crossAxisAlignment: .start,
+                          maxLines: 1,
+                        ),
+                      ),
+                      Expanded(flex: 4, child: sourceField),
+                    ],
+                  ),
+                  const GtGap.yBase(),
+                  Row(
+                    spacing: context.spacingsectionMd,
+                    children: [
+                      GtSizedBox(
+                        height: 90,
+                        width: 20,
+                        child: FractionalTranslation(
+                          translation: Offset(.5, 0),
+                          child: CustomPaint(
+                            painter: GtCenterLinePainter(
+                              color: context.palette.stroke.soft,
+                            ),
+                            child: Center(
+                              child: widget.middleIcon ?? separator,
+                            ),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: SingleChildScrollView(
+                          scrollDirection: .horizontal,
+                          physics: const GtMarqueeScrollPhysics(),
+                          child: widget.child ?? const SizedBox.shrink(),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const GtGap.yMd(),
+                  Row(
+                    spacing: context.spacingSm,
+                    children: [
+                      Expanded(
+                        flex: 6,
+                        child: _GtTransferParticipantWidget(
+                          key: ValueKey(second.label),
+                          data: second,
+                          footerSuffix: second.validate ? footer : null,
+                          footerStyle: second.validate ? subStyle : null,
+                          maxLines: 1,
+                        ),
+                      ),
+                      Expanded(flex: 4, child: targetField),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Align(
+              alignment: .center,
+              child: GtSizedBox(
+                width: 20,
+                height: context.spacingMd,
+                child: RepaintBoundary(
+                  child: ClipPath(
+                    clipper: ConcaveRadiusClipper(),
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(color: context.palette.bg.weak),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            GtTransferCategoryField(
+              controller: widget.categoryController,
+              onChanged: widget.onCategoryChanged,
+              leading: GtTextField(
+                controller: widget.noteController,
+                hintText: widget.noteHint,
+                isEnabled: widget.isEnabled,
+                decoration: context.inputStyles.plainDecoration,
+                onChanged: widget.onNoteChanged,
+              ),
             ),
           ],
         );
@@ -217,6 +484,7 @@ class _GtTransferParticipantWidget extends GtStatelessWidget {
   final String? footerSuffix;
   final TextStyle? footerStyle;
   final CrossAxisAlignment crossAxisAlignment;
+  final int? maxLines;
 
   const _GtTransferParticipantWidget({
     super.key,
@@ -224,6 +492,7 @@ class _GtTransferParticipantWidget extends GtStatelessWidget {
     required this.footerSuffix,
     this.crossAxisAlignment = .end,
     this.footerStyle,
+    this.maxLines,
   });
 
   @override
@@ -274,7 +543,175 @@ class _GtTransferParticipantWidget extends GtStatelessWidget {
           _ => crossAxisAlignment,
         },
         subStyle: footerStyle,
+        maxLines: maxLines,
       ),
     );
+  }
+}
+
+/// A dropdown widget for selecting a transaction category.
+class GtTransferCategoryField extends GtStatefulWidget {
+  /// The controller that manages the category of the transfer.
+  final GtTransactionCategoryController? controller;
+
+  /// Callback invoked whenever the category changes.
+  final OnChanged<GtTransactionCategory?>? onChanged;
+
+  /// The widget to display when there are no categories.
+  final Widget? emptyWidget;
+
+  /// The widget to display while loading categories.
+  final Widget? loadingWidget;
+
+  /// The leading widget.
+  final Widget? leading;
+
+  /// Indicates whether the category field is enabled.
+  final bool isEnabled;
+
+  /// Creates a new [GtTransferCategoryField].
+  const GtTransferCategoryField({
+    super.key,
+    this.controller,
+    this.onChanged,
+    this.emptyWidget,
+    this.loadingWidget,
+    this.leading,
+    this.isEnabled = true,
+  });
+
+  @override
+  State<GtTransferCategoryField> createState() =>
+      _GtTransferCategoryFieldState();
+}
+
+class _GtTransferCategoryFieldState extends State<GtTransferCategoryField>
+    with GtBottomSheetMixin, GtTransactionCategoryMixin {
+  late final GtTransactionCategoryController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    final defaultCtrl = GtTransactionCategoryController(
+      defaultInputCategories.first,
+      categories: defaultInputCategories,
+    );
+    controller = widget.controller ?? defaultCtrl;
+
+    if (!controller.categories.hasValue) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        controller.categories = defaultInputCategories;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    if (widget.controller != null) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  GtTransactionCategory get _fallbackCategory {
+    return defaultInputCategories.first;
+  }
+
+  FutureOr<List<GtDropdownData<GtTransactionCategory>>>
+  get _allCategories async {
+    List<GtTransactionCategory> categories = controller.categories;
+
+    if (!categories.hasValue) categories = defaultInputCategories;
+
+    return categories.mapList((it) => it.dropdownData);
+  }
+
+  void _showSheet() {
+    if (!widget.isEnabled) return;
+    final dropdownController = GtDropdownInputController(
+      selection: controller.value?.dropdownData,
+    );
+    showDraggableSheet(
+      context,
+      builder: (scrollController) => GtDropDownModal<GtTransactionCategory>(
+        autoFocus: true,
+        scrollController,
+        controller: dropdownController,
+        options: _allCategories,
+        debounceTime: 500.milliseconds,
+        emptyWidget: widget.emptyWidget,
+        loadingWidget: widget.loadingWidget,
+        builder: (value, value2) {
+          return GtSelectionListTile(
+            value.label.value,
+            value: value,
+            isSelected: value == value2.selection,
+            leading: GtImage(
+              image: value.value.image,
+              width: context.dp(32.px),
+              height: context.dp(32.px),
+            ),
+            onSelect: (val) {
+              value2.selection = value;
+              controller.select(value.value);
+              context.maybePop();
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                widget.onChanged?.call(value.value);
+              });
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = context.inputStyles.plainDecoration;
+
+    Widget child = GtDisabledOverlay(
+      !widget.isEnabled,
+      child: GtInkWell(
+        borderRadius: context.borderRadiusXl,
+        hapticFeedbackType: .medium,
+        onTap: _showSheet,
+        child: Container(
+          constraints: decoration.constraints,
+          padding: decoration.padding,
+          decoration: decoration.decoration,
+          alignment: .center,
+          child: ListenableBuilder(
+            listenable: controller,
+            builder: (context, child) {
+              final category = controller.value ?? _fallbackCategory;
+              final size = context.dp(32.px);
+
+              return Row(
+                crossAxisAlignment: .center,
+                mainAxisAlignment: .center,
+                spacing: context.spacingBase,
+                mainAxisSize: .min,
+                children: [
+                  GtImage(image: category.image, width: size, height: size),
+                  GtIcon(GtIcons.chevronDown, size: context.dp(16.px)),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    if (widget.leading != null) {
+      child = Row(
+        spacing: context.spacingBase,
+        children: [
+          Expanded(child: widget.leading!),
+          child,
+        ],
+      );
+    }
+
+    return child;
   }
 }

--- a/lib/widgets/molecules/tiles/gt_transaction_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_transaction_tiles.dart
@@ -151,6 +151,8 @@ class GtTransactionParticipantListTile extends GtStatelessWidget {
   /// Custom styling for the [superscript] text.
   final TextStyle? superscriptStyle;
 
+  final int? maxLines;
+
   /// Creates a [GtTransactionParticipantListTile].
   const GtTransactionParticipantListTile(
     this.title, {
@@ -163,6 +165,7 @@ class GtTransactionParticipantListTile extends GtStatelessWidget {
     this.subStyle,
     this.titleStyle,
     this.superscriptStyle,
+    this.maxLines,
   });
 
   @override
@@ -190,11 +193,21 @@ class GtTransactionParticipantListTile extends GtStatelessWidget {
                 GtText(
                   superscript?.upper,
                   style: superscriptStyle ?? defaultSupStyle,
+                  maxLines: 1,
                 ),
-              GtText(title, style: titleStyle ?? style.h7()),
+              GtText(
+                title,
+                style: titleStyle ?? style.buttonS(),
+                maxLines: maxLines,
+                overflow: maxLines != null ? .ellipsis : null,
+              ),
               if (subtitle.hasValue) ...[
                 const GtGap.ySm(),
-                GtText(subtitle, style: subStyle ?? defaultSubStyle),
+                GtText(
+                  subtitle,
+                  style: subStyle ?? defaultSubStyle,
+                  maxLines: maxLines,
+                ),
               ],
             ],
           ),

--- a/lib/widgets/organisms/grids/gt_transfer_category_grid.dart
+++ b/lib/widgets/organisms/grids/gt_transfer_category_grid.dart
@@ -2,21 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-/// A controller that manages the selection state of a [GtTransactionCategory].
-///
-/// It extends [ValueNotifier] to allow widgets to rebuild when the selected
-/// category changes.
-class GtTransferCategoryController
-    extends ValueNotifier<GtTransactionCategory?> {
-  /// Creates a [GtTransferCategoryController] with an initial [value].
-  GtTransferCategoryController(super.value);
-
-  /// Updates the currently selected category to the provided [category].
-  void select(GtTransactionCategory category) {
-    value = category;
-  }
-}
-
 /// A widget that displays a grid of selectable transaction categories.
 ///
 /// Uses a [Wrap] layout to present categories in a responsive grid. It combines
@@ -28,7 +13,7 @@ class GtTransferCategoryController
 class GtTransferCategoryGrid extends GtStatelessWidget
     with GtTransactionCategoryMixin {
   /// The controller managing the currently selected category.
-  final GtTransferCategoryController controller;
+  final GtTransactionCategoryController controller;
 
   /// An optional list of additional custom categories to append to the default list.
   final List<GtTransactionCategory> categories;
@@ -46,7 +31,7 @@ class GtTransferCategoryGrid extends GtStatelessWidget
 
   @override
   Widget build(BuildContext context) {
-    final allCategories = [...defaultCategories, ...categories];
+    final allCategories = [...defaultGridCategories, ...categories];
     final isMobile = context.screenType.isMobile;
 
     return GenericListener<GtTransactionCategory?>(
@@ -131,109 +116,4 @@ class GtTransactionCategoryGridCell extends GtStatelessWidget {
       ),
     );
   }
-}
-
-/// A mixin that provides a comprehensive list of default transaction categories.
-///
-/// These categories are commonly used in financial applications for classifying
-/// transfers, payments, and other transactions.
-mixin GtTransactionCategoryMixin {
-  /// A predefined list of standard [GtTransactionCategory] objects.
-  List<GtTransactionCategory> get defaultCategories => [
-    GtTransactionCategory(
-      label: "transfers".ctr(),
-      image: AppImageData.network(GtNetworkImages.transfer),
-      variant: .info,
-    ),
-    GtTransactionCategory(
-      label: "shopping".ctr(),
-      image: AppImageData.network(GtNetworkImages.shopping),
-      variant: .featured,
-    ),
-    GtTransactionCategory(
-      label: "payroll".ctr(),
-      image: AppImageData.network(GtNetworkImages.cash),
-      variant: .success,
-    ),
-    GtTransactionCategory(
-      label: "family".ctr(),
-      image: AppImageData.network(GtNetworkImages.family),
-      variant: .info,
-    ),
-    GtTransactionCategory(
-      label: "food".ctr(),
-      image: AppImageData.network(GtNetworkImages.food),
-      variant: .error,
-    ),
-    GtTransactionCategory(
-      label: "savings".ctr(),
-      image: AppImageData.network(GtNetworkImages.savings),
-      variant: .success,
-    ),
-    GtTransactionCategory(
-      label: "bills".ctr(),
-      image: AppImageData.network(GtNetworkImages.bill),
-      variant: .error,
-    ),
-    GtTransactionCategory(
-      label: "card".ctr(),
-      image: AppImageData.network(GtNetworkImages.card),
-      variant: .success,
-    ),
-    GtTransactionCategory(
-      label: "household".ctr(),
-      image: AppImageData.network(GtNetworkImages.household),
-      variant: .info,
-    ),
-    GtTransactionCategory(
-      label: "health".ctr(),
-      image: AppImageData.network(GtNetworkImages.health),
-      variant: .error,
-    ),
-    GtTransactionCategory(
-      label: "gift".ctr(),
-      image: AppImageData.network(GtNetworkImages.gift),
-      variant: .featured,
-    ),
-    GtTransactionCategory(
-      label: "charity".ctr(),
-      image: AppImageData.network(GtNetworkImages.charity),
-      variant: .success,
-    ),
-    GtTransactionCategory(
-      label: "holiday".ctr(),
-      image: AppImageData.network(GtNetworkImages.holiday),
-      variant: .featured,
-    ),
-    GtTransactionCategory(
-      label: "transport".ctr(),
-      image: AppImageData.network(GtNetworkImages.transport),
-      variant: .info,
-    ),
-    GtTransactionCategory(
-      label: "education".ctr(),
-      image: AppImageData.network(GtNetworkImages.school),
-      variant: .success,
-    ),
-    GtTransactionCategory(
-      label: "emergency".ctr(),
-      image: AppImageData.network(GtNetworkImages.alarm),
-      variant: .error,
-    ),
-    GtTransactionCategory(
-      label: "refund".ctr(),
-      image: AppImageData.network(GtNetworkImages.returns),
-      variant: .error,
-    ),
-    GtTransactionCategory(
-      label: "books".ctr(),
-      image: AppImageData.network(GtNetworkImages.books),
-      variant: .featured,
-    ),
-    GtTransactionCategory(
-      label: "fitness".ctr(),
-      image: AppImageData.network(GtNetworkImages.gym),
-      variant: .success,
-    ),
-  ];
 }


### PR DESCRIPTION
## Description

- **Purpose:** Feature / Refactor
- **Issue Link:** #141
- **Summary:** Implements FX Transfer Input support in `GtTransferField` and introduces category selection via `GtTransferCategoryField`, unified category data models, and updated gallery use-cases.

### Key Changes
- **Category Data Models & Controller:** Added `GtTransactionCategory`, `GtTransactionCategoryController`, and `GtTransactionCategoryMixin` under `lib/common/data/gt_transaction_category.dart` to manage category selection, images, and dropdown data.
- **FX & Category Transfer Inputs:** Enhanced `GtTransferField` and introduced `GtTransferCategoryField` in `lib/widgets/molecules/inputs/gt_transfer_field.dart`, enabling category picker bottom sheets, note field integration, and currency/amount transfer layouts.
- **Participant Tiles:** Updated `GtTransactionParticipantListTile` in `lib/widgets/molecules/tiles/gt_transaction_tiles.dart` with `maxLines` and ellipsis support for participant text wrapping.
- **Grid Refactoring:** Standardized `GtTransferCategoryGrid` to use `GtTransactionCategoryController` and default grid categories.
- **Gallery & Widgetbook:** Added and updated input use-cases in the gallery app (`gallery/lib/molecules/inputs/`) to showcase `GtTransferField`, `GtPhoneField`, `GtDateField`, and other input components with Widgetbook knobs.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)

<img width="2056" height="1285" alt="Screenshot 2026-07-30 at 13 34 55" src="https://github.com/user-attachments/assets/8494cf22-88d5-4c59-8f12-fa0a02e8ce4c" />
<img width="2056" height="1285" alt="Screenshot 2026-07-30 at 13 39 29" src="https://github.com/user-attachments/assets/d5a52c85-e50e-4a9e-b382-f9f23171f838" />
<img width="2056" height="1285" alt="Screenshot 2026-07-30 at 14 02 18" src="https://github.com/user-attachments/assets/801de5cc-594b-42ce-8212-afb5598a4ec1" />
<img width="2056" height="1285" alt="Screenshot 2026-07-30 at 14 02 50" src="https://github.com/user-attachments/assets/1795f18c-ec38-4469-a413-4c8008ab0328" />
<img width="2056" height="1285" alt="Screenshot 2026-07-30 at 14 10 26" src="https://github.com/user-attachments/assets/e336a6ba-6499-4a13-b03c-006d8ae29eed" />


## 🧪 How Has This Been Tested?

- [x] Unit Tests Added/Updated
- [ ] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:* 
    1. Run the gallery app or Widgetbook story for `GtTransferField`.
    2. Test tapping the category selector to open the `GtDropDownModal` bottom sheet and select a category.
    3. Verify amount inputs, currency symbols, and note fields update state correctly.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
