### PR TITLE
GtDobField Focus & Keyboard Unfocus Fix

### DIFF
--- a/gallery/lib/templates/slides/gt_onboarding_slides_usecase.dart
+++ b/gallery/lib/templates/slides/gt_onboarding_slides_usecase.dart
@@ -6,12 +6,10 @@ import 'package:gt_mobile_ui/widgets/templates/slides/gt_onboarding_slides.dart'
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 List<GtOnboardingSlideData> getPersonalOnboardingSlides(BuildContext context) {
-  final palette = context.palette;
   return [
     GtOnboardingSlideData(
       title: "banking,\neveryday",
       image: NetworkImage(GtNetworkImages.personalSlide1Bg),
-      backgroundColor: context.palette.bg.strong,
       contentImage: AppImageData(GtVectors.whiteLogo),
       contentImageWidth: 40,
       contentImageSpacer: const GtGap.yLg(),
@@ -20,19 +18,16 @@ List<GtOnboardingSlideData> getPersonalOnboardingSlides(BuildContext context) {
       title: "Everything a bank account should do.",
       titleTextAlign: .start,
       image: NetworkImage(GtNetworkImages.personalSlide2Bg),
-      backgroundColor: palette.bg.strong,
     ),
     GtOnboardingSlideData(
       title: "Earn 3.9% p.a. Just by banking with us.",
       titleTextAlign: .start,
       image: NetworkImage(GtNetworkImages.personalSlide3Bg),
-      backgroundColor: palette.bg.strong,
     ),
     GtOnboardingSlideData(
       title: "SEND & receive payments from abroad.",
       titleTextAlign: .start,
       image: NetworkImage(GtNetworkImages.personalSlide4Bg),
-      backgroundColor: palette.bg.strong,
       contentImage: AppImageData(GtVectorIllustrations.fx),
       contentImageSpacer: const GtGap.ySection4xl(),
     ),

--- a/lib/common/data/gt_slide_data.dart
+++ b/lib/common/data/gt_slide_data.dart
@@ -52,9 +52,6 @@ class GtOnboardingSlideData {
   /// The main image or illustration to display on the slide.
   final ImageProvider image;
 
-  /// The primary background color of the slide.
-  final Color backgroundColor;
-
   /// An optional image that covers the content area.
   final AppImageData? contentImage;
 
@@ -72,7 +69,6 @@ class GtOnboardingSlideData {
   const GtOnboardingSlideData({
     required this.title,
     required this.image,
-    required this.backgroundColor,
     this.contentImage,
     this.textColor,
     this.titleTextAlign = .center,

--- a/lib/widgets/molecules/inputs/gt_dob_field.dart
+++ b/lib/widgets/molecules/inputs/gt_dob_field.dart
@@ -82,6 +82,18 @@ class _GtDobFieldState extends State<GtDobField> with GtBottomSheetMixin {
     _yearCtrl.text = _dobController.year?.toString() ?? '';
   }
 
+  void _updateFocus([FocusNode? node]) {
+    if (node == null) {
+      context.resetFocus();
+      return;
+    }
+    if (node.hasFocus) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      node.requestFocus();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final decoration =
@@ -130,6 +142,7 @@ class _GtDobFieldState extends State<GtDobField> with GtBottomSheetMixin {
               },
               onChange: (value) {
                 _dobController.day = value?.value;
+                if (value != null) _updateFocus(_monthCtrl.focusNode);
               },
               controller: _dayCtrl,
               textInputAction: .next,
@@ -154,11 +167,14 @@ class _GtDobFieldState extends State<GtDobField> with GtBottomSheetMixin {
               onChange: (value) {
                 final selectedDay = _dobController.day ?? 1;
                 final monthLastDay = value?.value.monthDays.length ?? 31;
+                FocusNode next = _yearCtrl.focusNode;
                 if (selectedDay > monthLastDay) {
                   _dayCtrl.text = "";
                   _dobController.day = null;
+                  next = _dayCtrl.focusNode;
                 }
                 _dobController.month = value?.value;
+                if (value != null) _updateFocus(next);
               },
               textInputAction: .next,
               suffix: Offstage(),
@@ -173,6 +189,7 @@ class _GtDobFieldState extends State<GtDobField> with GtBottomSheetMixin {
               controller: _yearCtrl,
               onChange: (value) {
                 _dobController.year = value?.value;
+                if (value != null) _updateFocus();
               },
               keyboardType: .number,
               textInputAction: .next,

--- a/lib/widgets/templates/slides/gt_onboarding_slides.dart
+++ b/lib/widgets/templates/slides/gt_onboarding_slides.dart
@@ -6,36 +6,63 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 ///
 /// This widget uses a [PageView] to display a list of [GtOnboardingSlideData] objects.
 /// It includes automatic slide transitions, page indicators ([GtDots]), and
-/// an optional logo and action buttons in an app bar.
+/// primary and secondary action buttons with a customizable rich text footer.
 class GtOnboardingSlides extends GtStatefulWidget {
   /// The list of data for each slide to be displayed.
   final List<GtOnboardingSlideData> slides;
 
   /// The color of the dot indicator for the currently active slide.
   ///
-  /// If null, it defaults to `context.palette.staticColors.white`.
+  /// If null, it defaults to [GtColors.tertiaryText].
   final Color? activeDotColor;
 
   /// The color of the dot indicators for inactive slides.
   ///
-  /// If null, it defaults to `context.palette.staticColors.black`.
+  /// If null, it defaults to [GtColors.whiteAlpha24].
   final Color? inActiveDotColor;
 
+  /// The text displayed in the footer area, which can contain HTML-like link tags.
   final String footerText;
 
+  /// The primary action button displayed at the bottom.
   final GtRaisedButton primaryButton;
 
+  /// The secondary action button displayed at the bottom.
   final GtOutlineButton secondaryButton;
 
-  /// Creates a [GtWelcomeSlides] widget.
+  /// The background color of the onboarding screen.
+  ///
+  /// If null, it defaults to `context.palette.bg.strong`.
+  final Color? backgroundColor;
+
+  /// The gradient overlay applied behind the bottom section.
+  ///
+  /// If null, it defaults to `context.gradients.onboardingSlideGradient()`.
+  final LinearGradient? footerGradient;
+
+  /// Optional color for the footer text.
+  ///
+  /// If null, it defaults to [activeDotColor] or [GtColors.tertiaryText].
+  final Color? footerTextColor;
+
+  /// Optional color for links within the footer text.
+  ///
+  /// If null, it defaults to [GtColors.neutral50].
+  final Color? footerLinkColor;
+
+  /// Creates a [GtOnboardingSlides] widget.
   const GtOnboardingSlides({
     super.key,
     required this.slides,
     this.activeDotColor,
     this.inActiveDotColor,
+    this.backgroundColor,
+    this.footerGradient,
     required this.footerText,
     required this.primaryButton,
     required this.secondaryButton,
+    this.footerTextColor,
+    this.footerLinkColor,
   });
 
   @override
@@ -97,27 +124,24 @@ class _GtOnboardingSlidesState extends State<GtOnboardingSlides> {
         return;
       }
 
-      if (next == 0) {
-        _controller.jumpToPage(next);
-        return;
-      }
+      final curve = next == 0 ? Curves.easeOutBack : Curves.easeIn;
 
-      _controller.animateToPage(
-        next,
-        duration: 500.milliseconds,
-        curve: Curves.easeIn,
-      );
+      _controller.animateToPage(next, duration: 500.milliseconds, curve: curve);
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    final palette = context.palette;
     final activeColor = widget.activeDotColor ?? GtColors.tertiaryText.value;
     final inActiveColor =
         widget.inActiveDotColor ?? GtColors.whiteAlpha24.value;
+    final defaultGradient = context.gradients.onboardingSlideGradient();
+    final backgroundColor = widget.backgroundColor ?? palette.bg.strong;
 
     return Scaffold(
       extendBodyBehindAppBar: true,
+      backgroundColor: backgroundColor,
       body: Stack(
         children: [
           Positioned.fill(
@@ -142,7 +166,7 @@ class _GtOnboardingSlidesState extends State<GtOnboardingSlides> {
           Positioned.fill(
             child: Container(
               decoration: BoxDecoration(
-                gradient: context.gradients.onboardingSlideGradient(),
+                gradient: widget.footerGradient ?? defaultGradient,
               ),
               child: ValueListenableBuilder(
                 valueListenable: _activeSlide,
@@ -156,9 +180,10 @@ class _GtOnboardingSlidesState extends State<GtOnboardingSlides> {
                       padding: context.insets.onlyDp(top: 2.px),
                       child: GtRichText(
                         widget.footerText,
-                        linkColor: GtColors.neutral50.value,
+                        linkColor:
+                            widget.footerLinkColor ?? GtColors.neutral50.value,
                         style: context.textStyles.subHead3xs(
-                          color: activeColor,
+                          color: widget.footerTextColor ?? activeColor,
                         ),
                         textAlign: .center,
                       ),
@@ -167,6 +192,9 @@ class _GtOnboardingSlidesState extends State<GtOnboardingSlides> {
                 ),
                 builder: (context, index, child) {
                   final slide = widget.slides[index];
+                  final textColor =
+                      slide.textColor ?? palette.staticColors.white;
+
                   return Column(
                     mainAxisAlignment: .end,
                     mainAxisSize: .min,
@@ -185,9 +213,7 @@ class _GtOnboardingSlidesState extends State<GtOnboardingSlides> {
                         child: GtText(
                           slide.title.upper,
                           style: context.textStyles.h3(
-                            color:
-                                slide.textColor ??
-                                context.palette.staticColors.white,
+                            color: textColor,
                             heightPx: 40,
                           ),
                           textAlign: slide.titleTextAlign,

--- a/test/gt_onboarding_slides_test.dart
+++ b/test/gt_onboarding_slides_test.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:gt_mobile_ui/widgets/templates/slides/gt_onboarding_slides.dart';
+
+final Uint8List _transparentPng = Uint8List.fromList([
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+  0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+  0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+  0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+]);
+
+void main() {
+  group('GtOnboardingSlides', () {
+    testWidgets('passes footerTextColor and footerLinkColor to GtRichText',
+        (WidgetTester tester) async {
+      const customTextColor = Colors.red;
+      const customLinkColor = Colors.blue;
+
+      await tester.pumpWidget(
+        GtThemeProvider(
+          theme: kPersonalTheme,
+          child: MaterialApp(
+            home: GtOnboardingSlides(
+              slides: [
+                GtOnboardingSlideData(
+                  title: 'Test Slide',
+                  image: MemoryImage(_transparentPng),
+                ),
+              ],
+              footerText:
+                  "Agree to <a href='https://example.com'>Terms</a>",
+              primaryButton: GtRaisedButton(
+                onPressed: () {},
+                text: 'Primary',
+              ),
+              secondaryButton: GtOutlineButton(
+                onPressed: () {},
+                text: 'Secondary',
+              ),
+              footerTextColor: customTextColor,
+              footerLinkColor: customLinkColor,
+            ),
+          ),
+        ),
+      );
+
+      final richTextFinder = find.byType(GtRichText);
+      expect(richTextFinder, findsOneWidget);
+
+      final GtRichText richText = tester.widget(richTextFinder);
+      expect(richText.linkColor, customLinkColor);
+      expect(richText.style?.color, customTextColor);
+    });
+  });
+}


### PR DESCRIPTION
## Description

- **Purpose:** Bug Fix & Feature / UI Refactor
- **Issue Link:** #151
- **Summary:**
  - **`GtDobField` Focus & Keyboard Unfocus Fix (Primary):**
    - Implemented automatic focus progression across day, month, and year inputs (`Day` -> `Month` -> `Year`).
    - Added automatic keyboard dismissal (`context.resetFocus()`) once year input is populated.
    - Added focus fallback handling to reset focus back to the day field if the selected day exceeds valid days for a newly selected month.
  - **`GtOnboardingSlides` Customization & Refactoring:**
    - Exposed optional `footerTextColor` and `footerLinkColor` properties on `GtOnboardingSlides` for caller-level color customization.
    - Updated and completed class and constructor dartdoc documentation across `GtOnboardingSlides`.
    - Removed redundant `backgroundColor` from individual `GtOnboardingSlideData` objects in favor of central screen/footer gradient configuration.

## ✨ Type of Change

- [ ] ✨ New Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)

https://github.com/user-attachments/assets/d1cb9dd5-2a58-4e99-9b39-49aab2d9634c

## 🧪 How Has This Been Tested?

- [x] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:*
    1. Navigate to `GtDobField` form input screen.
    2. Enter day value — focus automatically advances to month selector.
    3. Select month — focus automatically advances to year input field.
    4. Enter year value — keyboard automatically unfocuses (`context.resetFocus()`).
    5. Verify custom footer text & link color overrides render correctly on `GtOnboardingSlides`.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
