### PR TITLE
Introduced the `GtStatusTracker` organism for rendering vertical status timelines

### DIFF
--- a/gallery/lib/main.directories.g.dart
+++ b/gallery/lib/main.directories.g.dart
@@ -240,6 +240,8 @@ import 'package:gallery/organisms/slides/gt_slide.dart'
     as _gallery_organisms_slides_gt_slide;
 import 'package:gallery/organisms/slides/gt_slide_usecase.dart'
     as _gallery_organisms_slides_gt_slide_usecase;
+import 'package:gallery/organisms/status/gt_status_tracker_usecase.dart'
+    as _gallery_organisms_status_gt_status_tracker_usecase;
 import 'package:gallery/organisms/switchers/gt_animated_fade_usecase.dart'
     as _gallery_organisms_switchers_gt_animated_fade_usecase;
 import 'package:gallery/organisms/switchers/gt_animated_slider_usecase.dart'
@@ -1906,6 +1908,21 @@ final directories = <_widgetbook.WidgetbookNode>[
                     name: 'GtWelcomeSlide',
                     builder: _gallery_organisms_slides_gt_slide_usecase
                         .playgroundGtWelcomeSlideUseCase,
+                  ),
+                ],
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookFolder(
+            name: 'status',
+            children: [
+              _widgetbook.WidgetbookComponent(
+                name: 'GtStatusTracker',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'GtStatusTracker',
+                    builder: _gallery_organisms_status_gt_status_tracker_usecase
+                        .playgroundGtStatusTrackerUseCase,
                   ),
                 ],
               ),

--- a/gallery/lib/organisms/organisms.dart
+++ b/gallery/lib/organisms/organisms.dart
@@ -3,4 +3,5 @@ export 'cards/cards.dart';
 export 'menus/menus.dart';
 export 'navigation/navigation.dart';
 export 'slides/slides.dart';
+export 'status/status.dart';
 export 'tab_bars/tab_bars.dart';

--- a/gallery/lib/organisms/status/gt_status_tracker_usecase.dart
+++ b/gallery/lib/organisms/status/gt_status_tracker_usecase.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:gallery/lib.dart';
+import 'package:gt_mobile_foundation/extensions/string_extensions.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(name: 'GtStatusTracker', type: GtStatusTracker)
+Widget playgroundGtStatusTrackerUseCase(BuildContext context) {
+  return const _StatusTrackerGalleryView();
+}
+
+class _StatusTrackerGalleryView extends StatefulWidget {
+  const _StatusTrackerGalleryView();
+
+  @override
+  State<_StatusTrackerGalleryView> createState() =>
+      _StatusTrackerGalleryViewState();
+}
+
+class _StatusTrackerGalleryViewState extends State<_StatusTrackerGalleryView>
+    with GtBottomModalMixin {
+  @override
+  Widget build(BuildContext context) {
+    final step1State = context.knobs.object.dropdown(
+      label: 'Step 1 State',
+      options: GtStatusStepState.values,
+      initialOption: GtStatusStepState.success,
+      labelBuilder: (s) => s.name,
+    );
+    final step2State = context.knobs.object.dropdown(
+      label: 'Step 2 State',
+      options: GtStatusStepState.values,
+      initialOption: GtStatusStepState.active,
+      labelBuilder: (s) => s.name,
+    );
+    final step3State = context.knobs.object.dropdown(
+      label: 'Step 3 State',
+      options: GtStatusStepState.values,
+      initialOption: GtStatusStepState.pending,
+      labelBuilder: (s) => s.name,
+    );
+
+    final step1Label = context.knobs.string(
+      label: 'Step 1 Label',
+      initialValue: 'Processed',
+    );
+    final step2Label = context.knobs.string(
+      label: 'Step 2 Label',
+      initialValue: 'Sending',
+    );
+    final step3Label = context.knobs.string(
+      label: 'Step 3 Label',
+      initialValue: 'Delivered',
+    );
+
+    final step1Sub = context.knobs.string(
+      label: 'Step 1 Subtitle',
+      initialValue: '10th Sept, 2025 11:03:00 AM',
+    );
+    final step2Sub = context.knobs.string(
+      label: 'Step 2 Subtitle',
+      initialValue: '10th Sept, 2025 11:03:00 AM',
+    );
+    final step3Sub = context.knobs.stringOrNull(
+      label: 'Step 3 Subtitle',
+      initialValue: null,
+    );
+
+    final currentSteps = [
+      GtStatusStepData(
+        label: step1Label,
+        state: step1State,
+        subtitle: step1Sub,
+      ),
+      GtStatusStepData(
+        label: step2Label,
+        state: step2State,
+        subtitle: step2Sub,
+      ),
+      GtStatusStepData(
+        label: step3Label,
+        state: step3State,
+        subtitle: step3Sub,
+      ),
+    ];
+
+    final codeSnippet =
+        '''
+GtStatusTracker(
+  steps: [
+    GtStatusStepData(
+      label: '$step1Label',
+      state: GtStatusStepState.${step1State.name},
+      subtitle: '$step1Sub',
+    ),
+    GtStatusStepData(
+      label: '$step2Label',
+      state: GtStatusStepState.${step2State.name},
+      subtitle: '$step2Sub',
+    ),
+    GtStatusStepData(
+      label: '$step3Label',
+      state: GtStatusStepState.${step3State.name},${step3Sub.hasValue ? '\n      subtitle: $step3Sub' : ''},
+    ),
+  ],
+)''';
+
+    return GtWidgetDocPage(
+      title: 'GtStatusTracker',
+      description: '''
+<b>GtStatusTracker</b> renders a vertical multi-step status timeline with semantic state indicators, connecting lines, and automatic terminal checkmarks.
+
+It seamlessly integrates inside floating bottom sheets or standalone card views.''',
+      code: codeSnippet,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: context.spacingLg,
+        children: [
+          GtCard(
+            padding: context.insets.allDp(20.px),
+            child: GtStatusTracker(steps: currentSteps),
+          ),
+          Wrap(
+            spacing: context.spacingMd,
+            runSpacing: context.spacingBase,
+            children: [
+              _ScenarioChip(
+                label: 'Test Processing',
+                onTap: () => _openSheetWith(context, [
+                  const GtStatusStepData(
+                    label: 'Processing',
+                    state: GtStatusStepState.active,
+                    subtitle: '10th Sept, 2025 11:03:00 AM',
+                  ),
+                  const GtStatusStepData(
+                    label: 'Sent',
+                    state: GtStatusStepState.pending,
+                  ),
+                  const GtStatusStepData(
+                    label: 'Delivered',
+                    state: GtStatusStepState.pending,
+                  ),
+                ]),
+              ),
+              _ScenarioChip(
+                label: 'Test Failed Sending',
+                onTap: () => _openSheetWith(context, [
+                  const GtStatusStepData(
+                    label: 'Processed',
+                    state: GtStatusStepState.success,
+                    subtitle: '10th Sept, 2025 11:03:00 AM',
+                  ),
+                  const GtStatusStepData(
+                    label: 'Sending',
+                    state: GtStatusStepState.failed,
+                    subtitle: 'Failed. 10th Sept, 2025 11:03:00 AM',
+                  ),
+                  const GtStatusStepData(
+                    label: 'Delivered',
+                    state: GtStatusStepState.pending,
+                  ),
+                ]),
+              ),
+              _ScenarioChip(
+                label: 'Test Reversed',
+                onTap: () => _openSheetWith(context, [
+                  const GtStatusStepData(
+                    label: 'Processed',
+                    state: GtStatusStepState.success,
+                    subtitle: '10th Sept, 2025 11:03:00 AM',
+                  ),
+                  const GtStatusStepData(
+                    label: 'Sending',
+                    state: GtStatusStepState.failed,
+                    subtitle: 'Failed. 10th Sept, 2025 11:03:00 AM',
+                  ),
+                  const GtStatusStepData(
+                    label: 'Reversed',
+                    state: GtStatusStepState.reversed,
+                    subtitle: '10th Sept, 2025 11:03:00 AM',
+                  ),
+                ]),
+              ),
+              _ScenarioChip(
+                label: 'Test Fully Delivered',
+                onTap: () => _openSheetWith(context, [
+                  const GtStatusStepData(
+                    label: 'Processed',
+                    state: GtStatusStepState.success,
+                    subtitle: '10th Sept, 2025 11:03:00 AM',
+                  ),
+                  const GtStatusStepData(
+                    label: 'Sent',
+                    state: GtStatusStepState.success,
+                    subtitle: '10th Sept, 2025 11:03:00 AM',
+                  ),
+                  const GtStatusStepData(
+                    label: 'Delivered',
+                    state: GtStatusStepState.success,
+                    subtitle: '10th Sept, 2025 11:03:00 AM',
+                  ),
+                ]),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openSheetWith(BuildContext context, List<GtStatusStepData> steps) {
+    showBottomModalWithChild(
+      context,
+      child: Padding(
+        padding: context.insets.defaultAllInsets,
+        child: GtStatusTracker(steps: steps),
+      ),
+    );
+  }
+}
+
+class _ScenarioChip extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+
+  const _ScenarioChip({required this.label, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GtRaisedButton(text: label, size: .pill, onPressed: onTap);
+  }
+}

--- a/gallery/lib/organisms/status/status.dart
+++ b/gallery/lib/organisms/status/status.dart
@@ -1,0 +1,1 @@
+export 'gt_status_tracker_usecase.dart';

--- a/lib/common/data/data.dart
+++ b/lib/common/data/data.dart
@@ -6,6 +6,7 @@ export 'gt_decoration_image_style.dart';
 export 'gt_input_data.dart';
 export 'gt_keycell_data.dart';
 export 'gt_slide_data.dart';
+export 'gt_status_step_data.dart';
 export 'gt_theme_setting.dart';
 export 'gt_transaction_category.dart';
 export 'gt_transfer_participant_data.dart';

--- a/lib/common/data/gt_status_step_data.dart
+++ b/lib/common/data/gt_status_step_data.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// Data model representing a single step within a [GtStatusTracker].
+@immutable
+class GtStatusStepData {
+  /// The main title text for the step.
+  final String label;
+
+  /// The visual status state of the step.
+  final GtStatusStepState state;
+
+  /// Optional detail text (e.g., date, timestamp, or failure reason) displayed below the label.
+  final String? subtitle;
+
+  /// Optional custom icon override. If null, a default icon based on [state] is used.
+  final IconData? icon;
+
+  /// Optional custom icon color override. If null, the color derived from [state] is used.
+  final Color? iconColor;
+
+  /// Optional custom subtitle text color override. If null, defaults to the standard neutral sub text color.
+  final Color? subtitleColor;
+
+  /// Creates a [GtStatusStepData].
+  const GtStatusStepData({
+    required this.label,
+    required this.state,
+    this.subtitle,
+    this.icon,
+    this.iconColor,
+    this.subtitleColor,
+  });
+
+  bool get isSuccess => state == .success;
+  bool get isFailure => state == .failed;
+  bool get isActive => state == .active;
+  bool get isPending => state == .pending;
+}

--- a/lib/common/styling/palettes/flex/dark.dart
+++ b/lib/common/styling/palettes/flex/dark.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class FlexDarkPalette extends GtPalette {
+final class FlexDarkPalette extends GtDarkPalette {
   FlexDarkPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class FlexDarkPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.green950.dark,
           light: GtColors.green200.dark,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.dark,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral50.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral12.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral500.dark,
-          darkerSub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral200.value,
-          dark: GtColors.neutral300.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutralAlpha24.value,
-          lighter: GtColors.neutralAlpha16.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue200.value,
-          dark: GtColors.blue400.value,
-          base: GtColors.blue600.value,
-          light: GtColors.blueAlpha24.value,
-          lighter: GtColors.blueAlpha16.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange200.value,
-          dark: GtColors.orange400.value,
-          base: GtColors.orange600.value,
-          light: GtColors.orangeAlpha16.value,
-          lighter: GtColors.orangeAlpha16.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red200.value,
-          dark: GtColors.red400.value,
-          base: GtColors.red600.value,
-          light: GtColors.redAlpha24.value,
-          lighter: GtColors.redAlpha16.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green200.value,
-          dark: GtColors.green400.value,
-          base: GtColors.green600.value,
-          light: GtColors.greenAlpha24.value,
-          lighter: GtColors.greenAlpha16.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow200.value,
-          dark: GtColors.yellow400.value,
-          base: GtColors.yellow600.value,
-          light: GtColors.yellowAlpha24.value,
-          lighter: GtColors.yellowAlpha16.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple200.value,
-          dark: GtColors.purple400.value,
-          base: GtColors.purple600.value,
-          light: GtColors.purpleAlpha24.value,
-          lighter: GtColors.purpleAlpha16.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky200.value,
-          dark: GtColors.sky400.value,
-          base: GtColors.sky600.value,
-          light: GtColors.skyAlpha24.value,
-          lighter: GtColors.skyAlpha16.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink200.value,
-          dark: GtColors.pink400.value,
-          base: GtColors.pink600.value,
-          light: GtColors.pinkAlpha24.value,
-          lighter: GtColors.pinkAlpha16.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal200.value,
-          dark: GtColors.teal400.value,
-          base: GtColors.teal600.value,
-          light: GtColors.tealAlpha24.value,
-          lighter: GtColors.tealAlpha16.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/flex/light.dart
+++ b/lib/common/styling/palettes/flex/light.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class FlexLightPalette extends GtPalette {
+final class FlexLightPalette extends GtLightPalette {
   FlexLightPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class FlexLightPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.green950.value,
           light: GtColors.green200.value,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.value,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral50.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral12.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral500.value,
-          darkerSub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          white: GtColors.neutral0.value,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral700.value,
-          dark: GtColors.neutral800.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutral200.value,
-          lighter: GtColors.neutral100.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue700.value,
-          dark: GtColors.blue950.value,
-          base: GtColors.blue500.value,
-          light: GtColors.blue200.value,
-          lighter: GtColors.blue50.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange700.value,
-          dark: GtColors.orange950.value,
-          base: GtColors.orange500.value,
-          light: GtColors.orange200.value,
-          lighter: GtColors.orange50.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red700.value,
-          dark: GtColors.red950.value,
-          base: GtColors.red500.value,
-          light: GtColors.red200.value,
-          lighter: GtColors.red50.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green700.value,
-          dark: GtColors.green950.value,
-          base: GtColors.green500.value,
-          light: GtColors.green200.value,
-          lighter: GtColors.green50.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow700.value,
-          dark: GtColors.yellow950.value,
-          base: GtColors.yellow500.value,
-          light: GtColors.yellow200.value,
-          lighter: GtColors.yellow50.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple700.value,
-          dark: GtColors.purple950.value,
-          base: GtColors.purple500.value,
-          light: GtColors.purple200.value,
-          lighter: GtColors.purple50.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky700.value,
-          dark: GtColors.sky950.value,
-          base: GtColors.sky500.value,
-          light: GtColors.sky200.value,
-          lighter: GtColors.sky50.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink700.value,
-          dark: GtColors.pink950.value,
-          base: GtColors.pink500.value,
-          light: GtColors.pink200.value,
-          lighter: GtColors.pink50.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal700.value,
-          dark: GtColors.teal950.value,
-          base: GtColors.teal500.value,
-          light: GtColors.teal200.value,
-          lighter: GtColors.teal50.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/gotech/dark.dart
+++ b/lib/common/styling/palettes/gotech/dark.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class GotechDarkPalette extends GtPalette {
+final class GotechDarkPalette extends GtDarkPalette {
   GotechDarkPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class GotechDarkPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.teal950.dark,
           light: GtColors.teal500.dark,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.dark,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral50.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral12.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral500.dark,
-          darkerSub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral200.value,
-          dark: GtColors.neutral300.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutralAlpha24.value,
-          lighter: GtColors.neutralAlpha16.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue200.value,
-          dark: GtColors.blue400.value,
-          base: GtColors.blue600.value,
-          light: GtColors.blueAlpha24.value,
-          lighter: GtColors.blueAlpha16.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange200.value,
-          dark: GtColors.orange400.value,
-          base: GtColors.orange600.value,
-          light: GtColors.orangeAlpha16.value,
-          lighter: GtColors.orangeAlpha16.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red200.value,
-          dark: GtColors.red400.value,
-          base: GtColors.red600.value,
-          light: GtColors.redAlpha24.value,
-          lighter: GtColors.redAlpha16.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green200.value,
-          dark: GtColors.green400.value,
-          base: GtColors.green600.value,
-          light: GtColors.greenAlpha24.value,
-          lighter: GtColors.greenAlpha16.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow200.value,
-          dark: GtColors.yellow400.value,
-          base: GtColors.yellow600.value,
-          light: GtColors.yellowAlpha24.value,
-          lighter: GtColors.yellowAlpha16.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple200.value,
-          dark: GtColors.purple400.value,
-          base: GtColors.purple600.value,
-          light: GtColors.purpleAlpha24.value,
-          lighter: GtColors.purpleAlpha16.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky200.value,
-          dark: GtColors.sky400.value,
-          base: GtColors.sky600.value,
-          light: GtColors.skyAlpha24.value,
-          lighter: GtColors.skyAlpha16.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink200.value,
-          dark: GtColors.pink400.value,
-          base: GtColors.pink600.value,
-          light: GtColors.pinkAlpha24.value,
-          lighter: GtColors.pinkAlpha16.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal200.value,
-          dark: GtColors.teal400.value,
-          base: GtColors.teal600.value,
-          light: GtColors.tealAlpha24.value,
-          lighter: GtColors.tealAlpha16.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/gotech/light.dart
+++ b/lib/common/styling/palettes/gotech/light.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class GotechLightPalette extends GtPalette {
+final class GotechLightPalette extends GtLightPalette {
   GotechLightPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class GotechLightPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.teal950.value,
           light: GtColors.teal500.value,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.value,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral50.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral12.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral500.value,
-          darkerSub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          white: GtColors.neutral0.value,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral700.value,
-          dark: GtColors.neutral800.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutral200.value,
-          lighter: GtColors.neutral100.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue700.value,
-          dark: GtColors.blue950.value,
-          base: GtColors.blue500.value,
-          light: GtColors.blue200.value,
-          lighter: GtColors.blue50.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange700.value,
-          dark: GtColors.orange950.value,
-          base: GtColors.orange500.value,
-          light: GtColors.orange200.value,
-          lighter: GtColors.orange50.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red700.value,
-          dark: GtColors.red950.value,
-          base: GtColors.red500.value,
-          light: GtColors.red200.value,
-          lighter: GtColors.red50.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green700.value,
-          dark: GtColors.green950.value,
-          base: GtColors.green500.value,
-          light: GtColors.green200.value,
-          lighter: GtColors.green50.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow700.value,
-          dark: GtColors.yellow950.value,
-          base: GtColors.yellow500.value,
-          light: GtColors.yellow200.value,
-          lighter: GtColors.yellow50.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple700.value,
-          dark: GtColors.purple950.value,
-          base: GtColors.purple500.value,
-          light: GtColors.purple200.value,
-          lighter: GtColors.purple50.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky700.value,
-          dark: GtColors.sky950.value,
-          base: GtColors.sky500.value,
-          light: GtColors.sky200.value,
-          lighter: GtColors.sky50.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink700.value,
-          dark: GtColors.pink950.value,
-          base: GtColors.pink500.value,
-          light: GtColors.pink200.value,
-          lighter: GtColors.pink50.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal700.value,
-          dark: GtColors.teal950.value,
-          base: GtColors.teal500.value,
-          light: GtColors.teal200.value,
-          lighter: GtColors.teal50.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/gt_palette.dart
+++ b/lib/common/styling/palettes/gt_palette.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gt_mobile_ui/common/styling/gt_colors.dart';
 
 // -----------------------------------------------------------------------------
 // PALETTE GROUPS
@@ -580,4 +581,362 @@ base class GtPalette extends ThemeExtension<GtPalette> {
     highlighted,
     stable,
   );
+}
+
+// -----------------------------------------------------------------------------
+// BASE LIGHT & DARK PALETTES
+// -----------------------------------------------------------------------------
+
+/// Base class for Light mode palettes providing standard default color definitions.
+base class GtLightPalette extends GtPalette {
+  GtLightPalette({
+    required super.primary,
+    required super.coverColors,
+    GtPaletteStaticColors? staticColors,
+    GtPaletteBgColors? bg,
+    GtPaletteBgColors? fill,
+    GtPaletteTextColors? text,
+    GtPaletteContentColors? icon,
+    GtPaletteStrokeColors? stroke,
+    GtPaletteStateColors? faded,
+    GtPaletteStateColors? information,
+    GtPaletteStateColors? warning,
+    GtPaletteStateColors? error,
+    GtPaletteStateColors? success,
+    GtPaletteStateColors? away,
+    GtPaletteStateColors? feature,
+    GtPaletteStateColors? verified,
+    GtPaletteStateColors? highlighted,
+    GtPaletteStateColors? stable,
+  }) : super(
+         staticColors:
+             staticColors ??
+             GtPaletteStaticColors(
+               black: GtColors.neutral950.value,
+               white: GtColors.neutral0.value,
+               shadow: GtColors.neutralGray700.value,
+             ),
+         bg:
+             bg ??
+             GtPaletteBgColors(
+               strong: GtColors.neutral950.value,
+               surface: GtColors.neutral800.value,
+               sub: GtColors.neutral300.value,
+               soft: GtColors.neutral200.value,
+               weak: GtColors.neutral50.value,
+               white: GtColors.neutral0.value,
+               warm: GtColors.yellow25.value,
+               neutralWarm50: GtColors.neutralWarm50.value,
+               weaker: GtColors.neutral25.value,
+               sky: GtColors.skyAlpha5.value,
+             ),
+         fill:
+             fill ??
+             GtPaletteBgColors(
+               strong: GtColors.neutral950.value,
+               surface: GtColors.neutral800.value,
+               sub: GtColors.neutral300.value,
+               soft: GtColors.neutral200.value,
+               weak: GtColors.neutral12.value,
+               white: GtColors.neutral0.value,
+               warm: GtColors.yellow25.value,
+               neutralWarm50: GtColors.neutralWarm50.value,
+               weaker: GtColors.neutral25.value,
+               sky: GtColors.skyAlpha5.value,
+             ),
+         text:
+             text ??
+             GtPaletteTextColors(
+               strong: GtColors.neutral950.value,
+               sub: GtColors.neutral500.value,
+               darkerSub: GtColors.neutral600.value,
+               soft: GtColors.neutral400.value,
+               disabled: GtColors.neutral300.value,
+               white: GtColors.neutral0.value,
+             ),
+         icon:
+             icon ??
+             GtPaletteContentColors(
+               strong: GtColors.neutral950.value,
+               sub: GtColors.neutral600.value,
+               soft: GtColors.neutral400.value,
+               disabled: GtColors.neutral300.value,
+               white: GtColors.neutral0.value,
+             ),
+         stroke:
+             stroke ??
+             GtPaletteStrokeColors(
+               strong: GtColors.neutral950.value,
+               sub: GtColors.neutral300.value,
+               soft: GtColors.neutral200.value,
+               white: GtColors.neutral0.value,
+             ),
+         faded:
+             faded ??
+             GtPaletteStateColors(
+               darker: GtColors.neutral700.value,
+               dark: GtColors.neutral800.value,
+               base: GtColors.neutral500.value,
+               light: GtColors.neutral200.value,
+               lighter: GtColors.neutral100.value,
+             ),
+         information:
+             information ??
+             GtPaletteStateColors(
+               darker: GtColors.blue700.value,
+               dark: GtColors.blue950.value,
+               base: GtColors.blue500.value,
+               light: GtColors.blue200.value,
+               lighter: GtColors.blue50.value,
+             ),
+         warning:
+             warning ??
+             GtPaletteStateColors(
+               darker: GtColors.orange700.value,
+               dark: GtColors.orange950.value,
+               base: GtColors.orange500.value,
+               light: GtColors.orange200.value,
+               lighter: GtColors.orange50.value,
+             ),
+         error:
+             error ??
+             GtPaletteStateColors(
+               darker: GtColors.red700.value,
+               dark: GtColors.red950.value,
+               base: GtColors.red500.value,
+               light: GtColors.red200.value,
+               lighter: GtColors.red50.value,
+             ),
+         success:
+             success ??
+             GtPaletteStateColors(
+               darker: GtColors.green700.value,
+               dark: GtColors.green950.value,
+               base: GtColors.green500.value,
+               light: GtColors.green200.value,
+               lighter: GtColors.green50.value,
+             ),
+         away:
+             away ??
+             GtPaletteStateColors(
+               darker: GtColors.yellow700.value,
+               dark: GtColors.yellow950.value,
+               base: GtColors.yellow500.value,
+               light: GtColors.yellow200.value,
+               lighter: GtColors.yellow50.value,
+             ),
+         feature:
+             feature ??
+             GtPaletteStateColors(
+               darker: GtColors.purple700.value,
+               dark: GtColors.purple950.value,
+               base: GtColors.purple500.value,
+               light: GtColors.purple200.value,
+               lighter: GtColors.purple50.value,
+             ),
+         verified:
+             verified ??
+             GtPaletteStateColors(
+               darker: GtColors.sky700.value,
+               dark: GtColors.sky950.value,
+               base: GtColors.sky500.value,
+               light: GtColors.sky200.value,
+               lighter: GtColors.sky50.value,
+             ),
+         highlighted:
+             highlighted ??
+             GtPaletteStateColors(
+               darker: GtColors.pink700.value,
+               dark: GtColors.pink950.value,
+               base: GtColors.pink500.value,
+               light: GtColors.pink200.value,
+               lighter: GtColors.pink50.value,
+             ),
+         stable:
+             stable ??
+             GtPaletteStateColors(
+               darker: GtColors.teal700.value,
+               dark: GtColors.teal950.value,
+               base: GtColors.teal500.value,
+               light: GtColors.teal200.value,
+               lighter: GtColors.teal50.value,
+             ),
+       );
+}
+
+/// Base class for Dark mode palettes providing standard default color definitions.
+base class GtDarkPalette extends GtPalette {
+  GtDarkPalette({
+    required super.primary,
+    required super.coverColors,
+    GtPaletteStaticColors? staticColors,
+    GtPaletteBgColors? bg,
+    GtPaletteBgColors? fill,
+    GtPaletteTextColors? text,
+    GtPaletteContentColors? icon,
+    GtPaletteStrokeColors? stroke,
+    GtPaletteStateColors? faded,
+    GtPaletteStateColors? information,
+    GtPaletteStateColors? warning,
+    GtPaletteStateColors? error,
+    GtPaletteStateColors? success,
+    GtPaletteStateColors? away,
+    GtPaletteStateColors? feature,
+    GtPaletteStateColors? verified,
+    GtPaletteStateColors? highlighted,
+    GtPaletteStateColors? stable,
+  }) : super(
+         staticColors:
+             staticColors ??
+             GtPaletteStaticColors(
+               black: GtColors.neutral950.value,
+               white: GtColors.neutral0.value,
+               shadow: GtColors.neutralGray700.dark,
+             ),
+         bg:
+             bg ??
+             GtPaletteBgColors(
+               strong: GtColors.neutral950.dark,
+               surface: GtColors.neutral800.dark,
+               sub: GtColors.neutral300.dark,
+               soft: GtColors.neutral200.dark,
+               weak: GtColors.neutral50.dark,
+               white: GtColors.neutral0.dark,
+               warm: GtColors.yellow25.dark,
+               neutralWarm50: GtColors.neutralWarm50.dark,
+               weaker: GtColors.neutral25.dark,
+               sky: GtColors.neutral200.dark,
+             ),
+         fill:
+             fill ??
+             GtPaletteBgColors(
+               strong: GtColors.neutral950.dark,
+               surface: GtColors.neutral800.dark,
+               sub: GtColors.neutral300.dark,
+               soft: GtColors.neutral200.dark,
+               weak: GtColors.neutral12.dark,
+               white: GtColors.neutral0.dark,
+               warm: GtColors.yellow25.dark,
+               neutralWarm50: GtColors.neutralWarm50.dark,
+               weaker: GtColors.neutral25.dark,
+               sky: GtColors.neutral200.dark,
+             ),
+         text:
+             text ??
+             GtPaletteTextColors(
+               strong: GtColors.neutral950.dark,
+               sub: GtColors.neutral500.dark,
+               darkerSub: GtColors.neutral600.dark,
+               soft: GtColors.neutral400.dark,
+               disabled: GtColors.neutral300.dark,
+               white: GtColors.neutral0.dark,
+             ),
+         icon:
+             icon ??
+             GtPaletteContentColors(
+               strong: GtColors.neutral950.dark,
+               sub: GtColors.neutral600.dark,
+               soft: GtColors.neutral400.dark,
+               disabled: GtColors.neutral300.dark,
+               white: GtColors.neutral0.dark,
+             ),
+         stroke:
+             stroke ??
+             GtPaletteStrokeColors(
+               strong: GtColors.neutral950.dark,
+               sub: GtColors.neutral300.dark,
+               soft: GtColors.neutral200.dark,
+               white: GtColors.neutral0.dark,
+             ),
+         faded:
+             faded ??
+             GtPaletteStateColors(
+               darker: GtColors.neutral700.dark,
+               dark: GtColors.neutral800.dark,
+               base: GtColors.neutral500.dark,
+               light: GtColors.neutral200.dark,
+               lighter: GtColors.neutral100.dark,
+             ),
+         information:
+             information ??
+             GtPaletteStateColors(
+               darker: GtColors.blue700.dark,
+               dark: GtColors.blue950.dark,
+               base: GtColors.blue500.dark,
+               light: GtColors.blue200.dark,
+               lighter: GtColors.blue50.dark,
+             ),
+         warning:
+             warning ??
+             GtPaletteStateColors(
+               darker: GtColors.orange700.dark,
+               dark: GtColors.orange950.dark,
+               base: GtColors.orange500.dark,
+               light: GtColors.orange200.dark,
+               lighter: GtColors.orange50.dark,
+             ),
+         error:
+             error ??
+             GtPaletteStateColors(
+               darker: GtColors.red700.dark,
+               dark: GtColors.red950.dark,
+               base: GtColors.red500.dark,
+               light: GtColors.red200.dark,
+               lighter: GtColors.red50.dark,
+             ),
+         success:
+             success ??
+             GtPaletteStateColors(
+               darker: GtColors.green700.dark,
+               dark: GtColors.green950.dark,
+               base: GtColors.green500.dark,
+               light: GtColors.green200.dark,
+               lighter: GtColors.green50.dark,
+             ),
+         away:
+             away ??
+             GtPaletteStateColors(
+               darker: GtColors.yellow700.dark,
+               dark: GtColors.yellow950.dark,
+               base: GtColors.yellow500.dark,
+               light: GtColors.yellow200.dark,
+               lighter: GtColors.yellow50.dark,
+             ),
+         feature:
+             feature ??
+             GtPaletteStateColors(
+               darker: GtColors.purple700.dark,
+               dark: GtColors.purple950.dark,
+               base: GtColors.purple500.dark,
+               light: GtColors.purple200.dark,
+               lighter: GtColors.purple50.dark,
+             ),
+         verified:
+             verified ??
+             GtPaletteStateColors(
+               darker: GtColors.sky700.dark,
+               dark: GtColors.sky950.dark,
+               base: GtColors.sky500.dark,
+               light: GtColors.sky200.dark,
+               lighter: GtColors.sky50.dark,
+             ),
+         highlighted:
+             highlighted ??
+             GtPaletteStateColors(
+               darker: GtColors.pink700.dark,
+               dark: GtColors.pink950.dark,
+               base: GtColors.pink500.dark,
+               light: GtColors.pink200.dark,
+               lighter: GtColors.pink50.dark,
+             ),
+         stable:
+             stable ??
+             GtPaletteStateColors(
+               darker: GtColors.teal700.dark,
+               dark: GtColors.teal950.dark,
+               base: GtColors.teal500.dark,
+               light: GtColors.teal200.dark,
+               lighter: GtColors.teal50.dark,
+             ),
+       );
 }

--- a/lib/common/styling/palettes/kids/dark.dart
+++ b/lib/common/styling/palettes/kids/dark.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class KidsDarkPalette extends GtPalette {
+final class KidsDarkPalette extends GtDarkPalette {
   KidsDarkPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class KidsDarkPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.purple950.dark,
           light: GtColors.purple200.dark,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.dark,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral50.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral12.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral500.dark,
-          darkerSub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral200.value,
-          dark: GtColors.neutral300.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutralAlpha24.value,
-          lighter: GtColors.neutralAlpha16.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue200.value,
-          dark: GtColors.blue400.value,
-          base: GtColors.blue600.value,
-          light: GtColors.blueAlpha24.value,
-          lighter: GtColors.blueAlpha16.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange200.value,
-          dark: GtColors.orange400.value,
-          base: GtColors.orange600.value,
-          light: GtColors.orangeAlpha16.value,
-          lighter: GtColors.orangeAlpha16.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red200.value,
-          dark: GtColors.red400.value,
-          base: GtColors.red600.value,
-          light: GtColors.redAlpha24.value,
-          lighter: GtColors.redAlpha16.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green200.value,
-          dark: GtColors.green400.value,
-          base: GtColors.green600.value,
-          light: GtColors.greenAlpha24.value,
-          lighter: GtColors.greenAlpha16.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow200.value,
-          dark: GtColors.yellow400.value,
-          base: GtColors.yellow600.value,
-          light: GtColors.yellowAlpha24.value,
-          lighter: GtColors.yellowAlpha16.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple200.value,
-          dark: GtColors.purple400.value,
-          base: GtColors.purple600.value,
-          light: GtColors.purpleAlpha24.value,
-          lighter: GtColors.purpleAlpha16.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky200.value,
-          dark: GtColors.sky400.value,
-          base: GtColors.sky600.value,
-          light: GtColors.skyAlpha24.value,
-          lighter: GtColors.skyAlpha16.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink200.value,
-          dark: GtColors.pink400.value,
-          base: GtColors.pink600.value,
-          light: GtColors.pinkAlpha24.value,
-          lighter: GtColors.pinkAlpha16.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal200.value,
-          dark: GtColors.teal400.value,
-          base: GtColors.teal600.value,
-          light: GtColors.tealAlpha24.value,
-          lighter: GtColors.tealAlpha16.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/kids/light.dart
+++ b/lib/common/styling/palettes/kids/light.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class KidsLightPalette extends GtPalette {
+final class KidsLightPalette extends GtLightPalette {
   KidsLightPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class KidsLightPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.purple950.value,
           light: GtColors.purple200.value,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.value,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral50.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral12.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral500.value,
-          darkerSub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          white: GtColors.neutral0.value,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral700.value,
-          dark: GtColors.neutral800.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutral200.value,
-          lighter: GtColors.neutral100.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue700.value,
-          dark: GtColors.blue950.value,
-          base: GtColors.blue500.value,
-          light: GtColors.blue200.value,
-          lighter: GtColors.blue50.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange700.value,
-          dark: GtColors.orange950.value,
-          base: GtColors.orange500.value,
-          light: GtColors.orange200.value,
-          lighter: GtColors.orange50.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red700.value,
-          dark: GtColors.red950.value,
-          base: GtColors.red500.value,
-          light: GtColors.red200.value,
-          lighter: GtColors.red50.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green700.value,
-          dark: GtColors.green950.value,
-          base: GtColors.green500.value,
-          light: GtColors.green200.value,
-          lighter: GtColors.green50.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow700.value,
-          dark: GtColors.yellow950.value,
-          base: GtColors.yellow500.value,
-          light: GtColors.yellow200.value,
-          lighter: GtColors.yellow50.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple700.value,
-          dark: GtColors.purple950.value,
-          base: GtColors.purple500.value,
-          light: GtColors.purple200.value,
-          lighter: GtColors.purple50.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky700.value,
-          dark: GtColors.sky950.value,
-          base: GtColors.sky500.value,
-          light: GtColors.sky200.value,
-          lighter: GtColors.sky50.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink700.value,
-          dark: GtColors.pink950.value,
-          base: GtColors.pink500.value,
-          light: GtColors.pink200.value,
-          lighter: GtColors.pink50.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal700.value,
-          dark: GtColors.teal950.value,
-          base: GtColors.teal500.value,
-          light: GtColors.teal200.value,
-          lighter: GtColors.teal50.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/personal/dark.dart
+++ b/lib/common/styling/palettes/personal/dark.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class PersonalDarkPalette extends GtPalette {
+final class PersonalDarkPalette extends GtDarkPalette {
   PersonalDarkPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class PersonalDarkPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.tealBlue800.dark,
           light: GtColors.white.value,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.dark,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral50.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral12.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral500.dark,
-          darkerSub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral200.value,
-          dark: GtColors.neutral300.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutralAlpha24.value,
-          lighter: GtColors.neutralAlpha16.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue200.value,
-          dark: GtColors.blue400.value,
-          base: GtColors.blue600.value,
-          light: GtColors.blueAlpha24.value,
-          lighter: GtColors.blueAlpha16.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange200.value,
-          dark: GtColors.orange400.value,
-          base: GtColors.orange600.value,
-          light: GtColors.orangeAlpha16.value,
-          lighter: GtColors.orangeAlpha16.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red200.value,
-          dark: GtColors.red400.value,
-          base: GtColors.red600.value,
-          light: GtColors.redAlpha24.value,
-          lighter: GtColors.redAlpha16.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green200.value,
-          dark: GtColors.green400.value,
-          base: GtColors.green600.value,
-          light: GtColors.greenAlpha24.value,
-          lighter: GtColors.greenAlpha16.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow200.value,
-          dark: GtColors.yellow400.value,
-          base: GtColors.yellow600.value,
-          light: GtColors.yellowAlpha24.value,
-          lighter: GtColors.yellowAlpha16.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple200.value,
-          dark: GtColors.purple400.value,
-          base: GtColors.purple600.value,
-          light: GtColors.purpleAlpha24.value,
-          lighter: GtColors.purpleAlpha16.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky200.value,
-          dark: GtColors.sky400.value,
-          base: GtColors.sky600.value,
-          light: GtColors.skyAlpha24.value,
-          lighter: GtColors.skyAlpha16.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink200.value,
-          dark: GtColors.pink400.value,
-          base: GtColors.pink600.value,
-          light: GtColors.pinkAlpha24.value,
-          lighter: GtColors.pinkAlpha16.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal200.value,
-          dark: GtColors.teal400.value,
-          base: GtColors.teal600.value,
-          light: GtColors.tealAlpha24.value,
-          lighter: GtColors.tealAlpha16.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/personal/light.dart
+++ b/lib/common/styling/palettes/personal/light.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class PersonalLightPalette extends GtPalette {
+final class PersonalLightPalette extends GtLightPalette {
   PersonalLightPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class PersonalLightPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.tealBlue800.value,
           light: GtColors.white.value,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.value,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral50.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral12.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral500.value,
-          darkerSub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          white: GtColors.neutral0.value,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral700.value,
-          dark: GtColors.neutral800.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutral200.value,
-          lighter: GtColors.neutral100.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue700.value,
-          dark: GtColors.blue950.value,
-          base: GtColors.blue500.value,
-          light: GtColors.blue200.value,
-          lighter: GtColors.blue50.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange700.value,
-          dark: GtColors.orange950.value,
-          base: GtColors.orange500.value,
-          light: GtColors.orange200.value,
-          lighter: GtColors.orange50.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red700.value,
-          dark: GtColors.red950.value,
-          base: GtColors.red500.value,
-          light: GtColors.red200.value,
-          lighter: GtColors.red50.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green700.value,
-          dark: GtColors.green950.value,
-          base: GtColors.green500.value,
-          light: GtColors.green200.value,
-          lighter: GtColors.green50.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow700.value,
-          dark: GtColors.yellow950.value,
-          base: GtColors.yellow500.value,
-          light: GtColors.yellow200.value,
-          lighter: GtColors.yellow50.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple700.value,
-          dark: GtColors.purple950.value,
-          base: GtColors.purple500.value,
-          light: GtColors.purple200.value,
-          lighter: GtColors.purple50.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky700.value,
-          dark: GtColors.sky950.value,
-          base: GtColors.sky500.value,
-          light: GtColors.sky200.value,
-          lighter: GtColors.sky50.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink700.value,
-          dark: GtColors.pink950.value,
-          base: GtColors.pink500.value,
-          light: GtColors.pink200.value,
-          lighter: GtColors.pink50.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal700.value,
-          dark: GtColors.teal950.value,
-          base: GtColors.teal500.value,
-          light: GtColors.teal200.value,
-          lighter: GtColors.teal50.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/sterling_pro/dark.dart
+++ b/lib/common/styling/palettes/sterling_pro/dark.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class SterlingProDarkPalette extends GtPalette {
+final class SterlingProDarkPalette extends GtDarkPalette {
   SterlingProDarkPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class SterlingProDarkPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.maroon800.dark,
           light: GtColors.neutral0.value,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.dark,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral50.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.dark,
-          surface: GtColors.neutral800.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          weak: GtColors.neutral12.dark,
-          white: GtColors.neutral0.dark,
-          warm: GtColors.yellow25.dark,
-          neutralWarm50: GtColors.neutralWarm50.dark,
-          weaker: GtColors.neutral25.dark,
-          sky: GtColors.neutral200.dark,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral500.dark,
-          darkerSub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral600.dark,
-          soft: GtColors.neutral400.dark,
-          disabled: GtColors.neutral300.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.dark,
-          sub: GtColors.neutral300.dark,
-          soft: GtColors.neutral200.dark,
-          white: GtColors.neutral0.dark,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral200.value,
-          dark: GtColors.neutral300.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutralAlpha24.value,
-          lighter: GtColors.neutralAlpha16.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue200.value,
-          dark: GtColors.blue400.value,
-          base: GtColors.blue600.value,
-          light: GtColors.blueAlpha24.value,
-          lighter: GtColors.blueAlpha16.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange200.value,
-          dark: GtColors.orange400.value,
-          base: GtColors.orange600.value,
-          light: GtColors.orangeAlpha16.value,
-          lighter: GtColors.orangeAlpha16.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red200.value,
-          dark: GtColors.red400.value,
-          base: GtColors.red600.value,
-          light: GtColors.redAlpha24.value,
-          lighter: GtColors.redAlpha16.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green200.value,
-          dark: GtColors.green400.value,
-          base: GtColors.green600.value,
-          light: GtColors.greenAlpha24.value,
-          lighter: GtColors.greenAlpha16.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow200.value,
-          dark: GtColors.yellow400.value,
-          base: GtColors.yellow600.value,
-          light: GtColors.yellowAlpha24.value,
-          lighter: GtColors.yellowAlpha16.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple200.value,
-          dark: GtColors.purple400.value,
-          base: GtColors.purple600.value,
-          light: GtColors.purpleAlpha24.value,
-          lighter: GtColors.purpleAlpha16.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky200.value,
-          dark: GtColors.sky400.value,
-          base: GtColors.sky600.value,
-          light: GtColors.skyAlpha24.value,
-          lighter: GtColors.skyAlpha16.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink200.value,
-          dark: GtColors.pink400.value,
-          base: GtColors.pink600.value,
-          light: GtColors.pinkAlpha24.value,
-          lighter: GtColors.pinkAlpha16.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal200.value,
-          dark: GtColors.teal400.value,
-          base: GtColors.teal600.value,
-          light: GtColors.tealAlpha24.value,
-          lighter: GtColors.tealAlpha16.value,
         ),
       );
 }

--- a/lib/common/styling/palettes/sterling_pro/light.dart
+++ b/lib/common/styling/palettes/sterling_pro/light.dart
@@ -1,6 +1,6 @@
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-final class SterlingProLightPalette extends GtPalette {
+final class SterlingProLightPalette extends GtLightPalette {
   SterlingProLightPalette()
     : super(
         primary: GtPaletteBrandColors(
@@ -14,126 +14,6 @@ final class SterlingProLightPalette extends GtPalette {
         coverColors: GtPaletteCoverColors(
           dark: GtColors.maroon800.value,
           light: GtColors.neutral0.value,
-        ),
-        staticColors: GtPaletteStaticColors(
-          black: GtColors.neutral950.value,
-          white: GtColors.neutral0.value,
-          shadow: GtColors.neutralGray700.value,
-        ),
-        bg: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral50.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        fill: GtPaletteBgColors(
-          strong: GtColors.neutral950.value,
-          surface: GtColors.neutral800.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          weak: GtColors.neutral12.value,
-          white: GtColors.neutral0.value,
-          warm: GtColors.yellow25.value,
-          neutralWarm50: GtColors.neutralWarm50.value,
-          weaker: GtColors.neutral25.value,
-          sky: GtColors.skyAlpha5.value,
-        ),
-        text: GtPaletteTextColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral500.value,
-          darkerSub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        icon: GtPaletteContentColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral600.value,
-          soft: GtColors.neutral400.value,
-          disabled: GtColors.neutral300.value,
-          white: GtColors.neutral0.value,
-        ),
-        stroke: GtPaletteStrokeColors(
-          strong: GtColors.neutral950.value,
-          sub: GtColors.neutral300.value,
-          soft: GtColors.neutral200.value,
-          white: GtColors.neutral0.value,
-        ),
-        faded: GtPaletteStateColors(
-          darker: GtColors.neutral700.value,
-          dark: GtColors.neutral800.value,
-          base: GtColors.neutral500.value,
-          light: GtColors.neutral200.value,
-          lighter: GtColors.neutral100.value,
-        ),
-        information: GtPaletteStateColors(
-          darker: GtColors.blue700.value,
-          dark: GtColors.blue950.value,
-          base: GtColors.blue500.value,
-          light: GtColors.blue200.value,
-          lighter: GtColors.blue50.value,
-        ),
-        warning: GtPaletteStateColors(
-          darker: GtColors.orange700.value,
-          dark: GtColors.orange950.value,
-          base: GtColors.orange500.value,
-          light: GtColors.orange200.value,
-          lighter: GtColors.orange50.value,
-        ),
-        error: GtPaletteStateColors(
-          darker: GtColors.red700.value,
-          dark: GtColors.red950.value,
-          base: GtColors.red500.value,
-          light: GtColors.red200.value,
-          lighter: GtColors.red50.value,
-        ),
-        success: GtPaletteStateColors(
-          darker: GtColors.green700.value,
-          dark: GtColors.green950.value,
-          base: GtColors.green500.value,
-          light: GtColors.green200.value,
-          lighter: GtColors.green50.value,
-        ),
-        away: GtPaletteStateColors(
-          darker: GtColors.yellow700.value,
-          dark: GtColors.yellow950.value,
-          base: GtColors.yellow500.value,
-          light: GtColors.yellow200.value,
-          lighter: GtColors.yellow50.value,
-        ),
-        feature: GtPaletteStateColors(
-          darker: GtColors.purple700.value,
-          dark: GtColors.purple950.value,
-          base: GtColors.purple500.value,
-          light: GtColors.purple200.value,
-          lighter: GtColors.purple50.value,
-        ),
-        verified: GtPaletteStateColors(
-          darker: GtColors.sky700.value,
-          dark: GtColors.sky950.value,
-          base: GtColors.sky500.value,
-          light: GtColors.sky200.value,
-          lighter: GtColors.sky50.value,
-        ),
-        highlighted: GtPaletteStateColors(
-          darker: GtColors.pink700.value,
-          dark: GtColors.pink950.value,
-          base: GtColors.pink500.value,
-          light: GtColors.pink200.value,
-          lighter: GtColors.pink50.value,
-        ),
-        stable: GtPaletteStateColors(
-          darker: GtColors.teal700.value,
-          dark: GtColors.teal950.value,
-          base: GtColors.teal500.value,
-          light: GtColors.teal200.value,
-          lighter: GtColors.teal50.value,
         ),
       );
 }

--- a/lib/widgets/organisms/organisms.dart
+++ b/lib/widgets/organisms/organisms.dart
@@ -10,6 +10,7 @@ export 'media/media.dart';
 export 'menus/menus.dart';
 export 'navigation/navigation.dart';
 export 'slides/slides.dart';
+export 'status/status.dart';
 export 'switchers/switchers.dart';
 export 'tab_bars/tab_bars.dart';
 export 'view_state/view_state.dart';

--- a/lib/widgets/organisms/status/enums/gt_status_step_state.dart
+++ b/lib/widgets/organisms/status/enums/gt_status_step_state.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// How a status step node is rendered in [GtStatusTrackerStep].
+enum GtStatusStepNodeKind {
+  /// Hollow circle for not-yet-reached steps.
+  outlineDot,
+
+  /// Solid circle for completed non-terminal steps.
+  filledDot,
+
+  /// Animated spinner for in-progress steps.
+  spinner,
+
+  /// Icon glyph (failed, reversed, terminal check, overrides).
+  icon,
+}
+
+/// Represents the visual semantic state of a step in a [GtStatusTracker].
+enum GtStatusStepState {
+  /// The step has not been reached yet.
+  pending,
+
+  /// The step is currently in progress.
+  active,
+
+  /// The step has completed successfully.
+  success,
+
+  /// The step failed during execution.
+  failed,
+
+  /// The step was reversed or rolled back.
+  reversed;
+
+  /// Returns the semantic color associated with this state using the given [palette].
+  Color color(GtPalette palette) => switch (this) {
+    .active => palette.away.base,
+    .success => palette.success.darker,
+    .failed => palette.error.base,
+    .reversed => palette.primary.base,
+    .pending => palette.icon.soft,
+  };
+
+  /// Returns the semantic text color associated with this state using the given [palette].
+  Color textColor(GtPalette palette) => switch (this) {
+    .pending => palette.text.darkerSub,
+    _ => color(palette),
+  };
+
+  /// Default node rendering strategy when no explicit icon override is provided.
+  GtStatusStepNodeKind get nodeKind => switch (this) {
+    .pending => GtStatusStepNodeKind.outlineDot,
+    .success => GtStatusStepNodeKind.filledDot,
+    .active => GtStatusStepNodeKind.spinner,
+    .failed || .reversed => GtStatusStepNodeKind.icon,
+  };
+
+  /// Default icon when [nodeKind] is [GtStatusStepNodeKind.icon].
+  ///
+  /// Terminal success swaps to [GtIcons.checkSolid] in the list widget.
+  IconData get icon => switch (this) {
+    .failed => GtIcons.cancel,
+    .reversed => GtIcons.refreshAlt,
+    .success => GtIcons.checkSolid,
+    .active || .pending => GtIcons.loader,
+  };
+}

--- a/lib/widgets/organisms/status/gt_status_tracker.dart
+++ b/lib/widgets/organisms/status/gt_status_tracker.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// A vertical status timeline widget that renders a list of [GtStatusStepData] items.
+///
+/// Automatically determines connector lines between steps and resolves terminal success checkmarks.
+class GtStatusTracker extends GtStatelessWidget {
+  /// The ordered list of step data items to display.
+  final List<GtStatusStepData> steps;
+
+  /// Optional padding around the status tracker list.
+  final EdgeInsetsGeometry? padding;
+
+  /// Creates a [GtStatusTracker].
+  const GtStatusTracker({super.key, required this.steps, this.padding});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!steps.hasValue) return const SizedBox.shrink();
+    Color connectorColor = context.palette.stroke.sub;
+    final isCompleted = steps.every((it) => it.isSuccess);
+
+    if (isCompleted) {
+      connectorColor = context.palette.success.darker;
+    }
+
+    Widget content = Column(
+      mainAxisSize: .min,
+      crossAxisAlignment: .stretch,
+      spacing: context.spacingSm,
+      children: [
+        for (final (index, step) in steps.indexed) ...[
+          GtStatusTrackerStep(
+            data: step,
+            showAsTerminalSuccess: index == steps.length - 1,
+            key: ValueKey((step.label, step.state, index)),
+          ),
+          if (index < steps.length - 1)
+            GtStatusTrackerStepConnector(connectorColor),
+        ],
+      ],
+    );
+
+    if (padding != null) {
+      content = Padding(padding: padding!, child: content);
+    }
+
+    return content;
+  }
+}

--- a/lib/widgets/organisms/status/gt_status_tracker_step.dart
+++ b/lib/widgets/organisms/status/gt_status_tracker_step.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// Renders a single step row in a [GtStatusTracker], including its node,
+/// uppercase label, subtitle, and vertical connecting line.
+class GtStatusTrackerStep extends GtStatelessWidget {
+  /// The data specifying label, subtitle, state, and explicit color/icon overrides.
+  final GtStatusStepData data;
+
+  /// Whether this success step is the terminal completed step (checkmark).
+  final bool showAsTerminalSuccess;
+
+  /// Creates a [GtStatusTrackerStep].
+  const GtStatusTrackerStep({
+    super.key,
+    required this.data,
+    this.showAsTerminalSuccess = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    final textColor = data.state.textColor(palette);
+
+    Color subColor = palette.text.disabled;
+    if (data.subtitleColor != null) {
+      subColor = data.subtitleColor!;
+    }
+
+    TableCellVerticalAlignment cellAlignment = .top;
+    if (!data.subtitle.hasValue) cellAlignment = .middle;
+
+    return IntrinsicHeight(
+      child: Table(
+        defaultVerticalAlignment: cellAlignment,
+        columnWidths: {
+          0: FixedColumnWidth(context.dp(18.px)),
+          1: FixedColumnWidth(context.dp(8.px)),
+          2: FlexColumnWidth(),
+        },
+        children: [
+          TableRow(
+            children: [
+              _StatusNode(data, showAsTerminalSuccess: showAsTerminalSuccess),
+              const SizedBox.shrink(),
+              Column(
+                crossAxisAlignment: .start,
+                mainAxisSize: .min,
+                spacing: context.spacingSm,
+                children: [
+                  GtText(
+                    data.label.upper,
+                    style: context.textStyles.button2s(
+                      color: textColor,
+                      heightPx: 12,
+                    ),
+                  ),
+                  if (data.subtitle.hasValue)
+                    GtText(
+                      data.subtitle.value,
+                      style: context.textStyles.bodyXs(
+                        color: subColor,
+                        heightPx: 12,
+                      ),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Renders a vertical connecting line segment between steps in a [GtStatusTracker].
+class GtStatusTrackerStepConnector extends GtStatelessWidget {
+  /// The color of the connecting line segment.
+  final Color color;
+
+  /// Creates a [GtStatusTrackerStepConnector].
+  const GtStatusTrackerStepConnector(this.color, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Table(
+        defaultVerticalAlignment: .middle,
+        columnWidths: {
+          0: FixedColumnWidth(context.dp(18.px)),
+          1: FixedColumnWidth(context.dp(8.px)),
+          2: FlexColumnWidth(),
+        },
+        children: [
+          TableRow(
+            children: [
+              Container(
+                height: context.dp(21.px),
+                alignment: .center,
+                child: GtSizedBox(
+                  height: 12,
+                  child: VerticalDivider(color: color, width: 2, thickness: 2),
+                ),
+              ),
+              ...const SizedBox.shrink() * 2,
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusDot extends StatelessWidget {
+  final Color color;
+  final bool filled;
+  final double size;
+
+  const _StatusDot({
+    required this.color,
+    required this.filled,
+    required this.size,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: filled ? color : Colors.transparent,
+        shape: BoxShape.circle,
+        border: Border.all(color: color, width: 2.25),
+      ),
+    );
+  }
+}
+
+class _StatusNode extends StatelessWidget {
+  final GtStatusStepData data;
+  final bool showAsTerminalSuccess;
+
+  const _StatusNode(this.data, {required this.showAsTerminalSuccess});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final nodeColor = data.iconColor ?? data.state.color(palette);
+    final size = context.dp(16.px);
+
+    if (data.icon != null) {
+      return GtIcon.withColor(data.icon!, color: nodeColor, size: size);
+    }
+
+    if (showAsTerminalSuccess && data.state == GtStatusStepState.success) {
+      return GtIcon.withColor(GtIcons.checkSolid, color: nodeColor, size: size);
+    }
+
+    return switch (data.state.nodeKind) {
+      .spinner => GtSpinner(
+        color: nodeColor,
+        size: size,
+        strokeWidth: 3,
+        alignment: .topCenter,
+      ),
+      .filledDot => _StatusDot(color: nodeColor, filled: true, size: size),
+      .outlineDot => _StatusDot(color: nodeColor, filled: false, size: size),
+      .icon => GtIcon.withColor(data.state.icon, color: nodeColor, size: size),
+    };
+  }
+}

--- a/lib/widgets/organisms/status/status.dart
+++ b/lib/widgets/organisms/status/status.dart
@@ -1,0 +1,3 @@
+export 'enums/gt_status_step_state.dart';
+export 'gt_status_tracker.dart';
+export 'gt_status_tracker_step.dart';

--- a/lib/widgets/templates/modals/gt_bottom_modal.dart
+++ b/lib/widgets/templates/modals/gt_bottom_modal.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-/// An animated bottom modal container for displaying static content or tracking asynchronous tasks.
+/// An animated bottom modal container for displaying static content, custom child widgets, or tracking asynchronous tasks.
 ///
 /// This widget can be used standalone or presented via overlay APIs (like [showModalBottomSheet]).
 /// When driven by a [GtBottomModalController], it animates seamlessly between loading, success,
@@ -10,6 +10,7 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 class GtBottomModal extends StatefulWidget {
   final GtBottomModalController? _controller;
   final GtBottomModalData? _data;
+  final Widget? _child;
 
   /// Optional margin to apply around the modal container.
   ///
@@ -28,6 +29,7 @@ class GtBottomModal extends StatefulWidget {
     super.key,
     this.alignment = .bottomCenter,
   }) : _data = data,
+       _child = null,
        _controller = null;
 
   /// Creates a [GtBottomModal] whose state is managed dynamically by a [controller].
@@ -37,7 +39,18 @@ class GtBottomModal extends StatefulWidget {
     super.key,
     this.alignment = .bottomCenter,
   }) : _controller = controller,
+       _child = null,
        _data = null;
+
+  /// Creates a [GtBottomModal] that displays a custom [child] widget.
+  const GtBottomModal.child({
+    required Widget child,
+    this.margin,
+    super.key,
+    this.alignment = .bottomCenter,
+  }) : _controller = null,
+       _data = null,
+       _child = child;
 
   /// The controller managing this modal, if any.
   GtBottomModalController? get controller => _controller;
@@ -120,7 +133,7 @@ class _GtBottomModalState extends State<GtBottomModal>
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.hasController) {
+    if (widget._child != null || !widget.hasController) {
       return Material(
         type: .transparency,
         child: GestureDetector(
@@ -128,18 +141,29 @@ class _GtBottomModalState extends State<GtBottomModal>
           onTap: context.pop,
           child: Align(
             alignment: widget.alignment,
-            child: _GtModalBody(
-              titleSlide: _titleSlide,
-              titleFade: _titleFade,
-              successSlide: _successSlide,
-              successFade: _successFade,
-              title: widget.title,
-              icon: _GtBottomModalIconWidget(
-                GtBottomModalPhase.idle,
-                icon: widget.icon,
-              ),
-              description: widget.description,
-              margin: widget.margin,
+            child: Builder(
+              builder: (context) {
+                if (widget._child != null) {
+                  return _GtModalBodyWithChild(
+                    margin: widget.margin,
+                    child: widget._child!,
+                  );
+                }
+
+                return _GtModalBody(
+                  titleSlide: _titleSlide,
+                  titleFade: _titleFade,
+                  successSlide: _successSlide,
+                  successFade: _successFade,
+                  title: widget.title,
+                  icon: _GtBottomModalIconWidget(
+                    GtBottomModalPhase.idle,
+                    icon: widget.icon,
+                  ),
+                  description: widget.description,
+                  margin: widget.margin,
+                );
+              },
             ),
           ),
         ),
@@ -274,18 +298,7 @@ class _GtModalBody extends GtStatelessWidget {
                 mainAxisSize: .min,
                 crossAxisAlignment: .center,
                 children: [
-                  Align(
-                    alignment: .topCenter,
-                    child: Container(
-                      margin: context.insets.onlyDp(bottom: 16.px),
-                      width: context.dp(32.px),
-                      height: context.dp(4.px),
-                      decoration: BoxDecoration(
-                        color: palette.stroke.sub,
-                        borderRadius: context.borderRadiusXxs,
-                      ),
-                    ),
-                  ),
+                  const _GtBottomModalHandle(),
                   ?icon,
                   const GtGap.yBase(),
                   Flexible(
@@ -324,6 +337,53 @@ class _GtModalBody extends GtStatelessWidget {
   }
 }
 
+/// Internal widget that renders a modal container wrapping a custom child widget.
+class _GtModalBodyWithChild extends GtStatelessWidget {
+  /// The child widget displayed inside the modal.
+  final Widget child;
+
+  /// Margin applied around the modal container.
+  final EdgeInsetsGeometry? margin;
+
+  const _GtModalBodyWithChild({required this.child, this.margin});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final resolvedMargin =
+        margin ??
+        context.insets.onlyDp(left: 16.px, right: 16.px, bottom: 34.px);
+
+    return SafeArea(
+      top: false,
+      child: GestureDetector(
+        onVerticalDragEnd: (details) {
+          if (details.velocity.pixelsPerSecond.dy < 0.0) return;
+          context.pop();
+        },
+        child: Container(
+          constraints: BoxConstraints(maxWidth: 500),
+          width: double.infinity,
+          margin: resolvedMargin,
+          padding: context.insets.symmetricDp(vertical: 8.px),
+          decoration: BoxDecoration(
+            color: palette.bg.white,
+            borderRadius: context.borderRadius4Xl,
+          ),
+          child: Column(
+            mainAxisSize: .min,
+            crossAxisAlignment: .center,
+            children: [
+              const _GtBottomModalHandle(),
+              Flexible(child: child),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Resolves leading icon/loader for the current phase.
 class _GtBottomModalIconWidget extends StatelessWidget {
   /// The current phase of the modal (idle, loading, success, error).
@@ -354,5 +414,26 @@ class _GtBottomModalIconWidget extends StatelessWidget {
       .error => GtSvg(GtVectorIllustrations.failed, width: size, height: size),
       _ => child,
     };
+  }
+}
+
+/// Renders the top drag handle pill for the modal.
+class _GtBottomModalHandle extends StatelessWidget {
+  const _GtBottomModalHandle();
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: .topCenter,
+      child: Container(
+        margin: context.insets.onlyDp(bottom: 16.px),
+        width: context.dp(32.px),
+        height: context.dp(4.px),
+        decoration: BoxDecoration(
+          color: context.palette.stroke.sub,
+          borderRadius: context.borderRadiusXxs,
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/templates/modals/mixins/gt_modals_mixins.dart
+++ b/lib/widgets/templates/modals/mixins/gt_modals_mixins.dart
@@ -27,6 +27,20 @@ mixin GtBottomModalMixin {
     );
   }
 
+  /// Displays a simple bottom modal with a [title], an optional [description], and an optional [icon].
+  ///
+  /// The modal adapts its alignment based on the platform (bottom center on mobile, center elsewhere).
+  void showBottomModalWithChild(BuildContext context, {required Widget child}) {
+    _showModal(
+      context,
+      modal: GtBottomModal.child(
+        key: ValueKey(("gt-bottom-modal-child", child.hashCode)),
+        alignment: context.isMobile ? .bottomCenter : .center,
+        child: child,
+      ),
+    );
+  }
+
   /// Displays a bottom modal that is driven by a [GtBottomModalController].
   ///
   /// This is typically used for modals that reflect the progress or state of an asynchronous task.

--- a/test/gt_status_tracker_test.dart
+++ b/test/gt_status_tracker_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+void main() {
+  group('GtStatusTracker tests', () {
+    Widget buildTestWidget(Widget child) {
+      return GtThemeProvider(
+        theme: kPersonalTheme,
+        child: MaterialApp(home: Scaffold(body: child)),
+      );
+    }
+
+    testWidgets('renders all steps with labels and subtitles', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtStatusTracker(
+            steps: const [
+              GtStatusStepData(
+                label: 'Processed',
+                state: GtStatusStepState.success,
+                subtitle: '10th Sept, 2025',
+              ),
+              GtStatusStepData(
+                label: 'Sending',
+                state: GtStatusStepState.active,
+                subtitle: 'In progress',
+              ),
+              GtStatusStepData(
+                label: 'Delivered',
+                state: GtStatusStepState.pending,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('PROCESSED'), findsOneWidget);
+      expect(find.text('SENDING'), findsOneWidget);
+      expect(find.text('DELIVERED'), findsOneWidget);
+      expect(find.text('10th Sept, 2025'), findsOneWidget);
+      expect(find.text('In progress'), findsOneWidget);
+    });
+
+    testWidgets('renders GtSpinner for active step state', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtStatusTracker(
+            steps: const [
+              GtStatusStepData(
+                label: 'Processing',
+                state: GtStatusStepState.active,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.byType(GtSpinner), findsOneWidget);
+      expect(find.text('PROCESSING'), findsOneWidget);
+    });
+
+    testWidgets('resolves terminal success checkmark automatically', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtStatusTracker(
+            steps: const [
+              GtStatusStepData(
+                label: 'Processed',
+                state: GtStatusStepState.success,
+              ),
+              GtStatusStepData(label: 'Sent', state: GtStatusStepState.success),
+              GtStatusStepData(
+                label: 'Delivered',
+                state: GtStatusStepState.pending,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final stepFinders = find.byType(GtStatusTrackerStep);
+      expect(stepFinders, findsNWidgets(3));
+
+      final thirdStep = tester.widget<GtStatusTrackerStep>(stepFinders.at(2));
+      expect(thirdStep.showAsTerminalSuccess, isTrue);
+
+      final secondStep = tester.widget<GtStatusTrackerStep>(stepFinders.at(1));
+      expect(secondStep.showAsTerminalSuccess, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description

- **Purpose:** Feature / UI/UX Change / Refactoring
- **Issue Link:** #142
- **Summary:** Introduced the `GtStatusTracker` organism for rendering vertical status timelines (e.g. transaction processing steps). Added state styling, connector dividers, node icons/spinners, and custom bottom modal support via `GtBottomModal.child` and `showBottomModalWithChild`. Included Widgetbook gallery use-case scenarios and unit/widget tests.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)


https://github.com/user-attachments/assets/129e8d91-f5fb-471f-b13f-4bec33728462


## 🧪 How Has This Been Tested?

- [ ] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:* 
    1. Open Widgetbook / Gallery app and navigate to `Organisms > Status > GtStatusTracker`.
    2. Test interactive knobs (Step 1-3 labels, states, and subtitles).
    3. Tap scenario chips (*Test Processing*, *Test Failed Sending*, *Test Reversed*, *Test Fully Delivered*) to open floating status bottom modals.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
