### PR TITLE
refactor: improve modal navigation by adding configurable useRootNavi…

### DIFF
--- a/gallery/lib/addons/gt_theme_addon.dart
+++ b/gallery/lib/addons/gt_theme_addon.dart
@@ -71,7 +71,7 @@ class GtThemeAddon extends WidgetbookAddon<GtThemeSetting> {
             darkTheme: setting.theme.materialDark,
             themeMode: setting.mode,
             debugShowCheckedModeBanner: false,
-            navigatorKey: GtRouter.navigatorKey,
+            navigatorObservers: [GtRouter.observer],
             home: MediaQuery(
               data: MediaQuery.of(
                 context,

--- a/gallery/lib/organisms/status/gt_status_tracker_usecase.dart
+++ b/gallery/lib/organisms/status/gt_status_tracker_usecase.dart
@@ -216,6 +216,7 @@ It seamlessly integrates inside floating bottom sheets or standalone card views.
         padding: context.insets.defaultAllInsets,
         child: GtStatusTracker(steps: steps),
       ),
+      useRootNavigator: false,
     );
   }
 }

--- a/gallery/lib/templates/modals/gt_bottom_modal.dart
+++ b/gallery/lib/templates/modals/gt_bottom_modal.dart
@@ -140,6 +140,7 @@ class MyState extends State<MyWidget> with GtBottomModalMixin {
                 title: modalTitle,
                 description: modalDesc,
                 icon: AppImageData.asset(GtVectors.caution),
+                useRootNavigator: false,
               );
             },
           ),
@@ -148,7 +149,11 @@ class MyState extends State<MyWidget> with GtBottomModalMixin {
             variant: GtButtonVariant.success,
             onPressed: () async {
               _controller.reset();
-              showTaskBottomModal(context, controller: _controller);
+              showTaskBottomModal(
+                context,
+                controller: _controller,
+                useRootNavigator: false,
+              );
               _controller.complete(await _getSuccessFuture());
             },
           ),
@@ -157,7 +162,11 @@ class MyState extends State<MyWidget> with GtBottomModalMixin {
             variant: GtButtonVariant.destructive,
             onPressed: () async {
               _controller.reset();
-              showTaskBottomModal(context, controller: _controller);
+              showTaskBottomModal(
+                context,
+                controller: _controller,
+                useRootNavigator: false,
+              );
               _controller.complete(await _getFailureFuture());
             },
           ),
@@ -166,7 +175,11 @@ class MyState extends State<MyWidget> with GtBottomModalMixin {
             variant: GtButtonVariant.secondary,
             onPressed: () async {
               _controller.reset();
-              showTaskBottomModal(context, controller: _controller);
+              showTaskBottomModal(
+                context,
+                controller: _controller,
+                useRootNavigator: false,
+              );
               _controller.complete(
                 await _getProgressFuture(
                   onProgress: (value) {

--- a/gallery/lib/templates/modals/gt_bottom_sheet.dart
+++ b/gallery/lib/templates/modals/gt_bottom_sheet.dart
@@ -111,6 +111,7 @@ class MyState extends State<MyWidget> with GtBottomSheetMixin {
                 context,
                 maxHeightFraction: .5,
                 floating: floating,
+                useRootNavigator: false,
                 child: GtStatusState.success(
                   title: "successful !",
                   subtitle:
@@ -128,6 +129,7 @@ class MyState extends State<MyWidget> with GtBottomSheetMixin {
               showSheet(
                 context,
                 maxHeightFraction: .5,
+                useRootNavigator: false,
                 floating: true,
                 isScrollable: true,
                 child: Column(
@@ -184,6 +186,7 @@ class MyState extends State<MyWidget> with GtBottomSheetMixin {
                 initialChildSize: .3,
                 maxHeightFraction: .7,
                 floating: floating,
+                useRootNavigator: false,
                 builder: (value) {
                   return SingleChildScrollView(
                     controller: value,
@@ -214,6 +217,7 @@ class MyState extends State<MyWidget> with GtBottomSheetMixin {
                 maxChildSize: .5,
                 minChildSize: .2,
                 floating: true,
+                useRootNavigator: false,
                 builder: (value) {
                   return ListView(
                     controller: value,

--- a/gallery/lib/templates/modals/gt_success_rate_modal_usecase.dart
+++ b/gallery/lib/templates/modals/gt_success_rate_modal_usecase.dart
@@ -185,6 +185,7 @@ class _SuccessRateModalPreviewState extends State<_SuccessRateModalPreview>
       initialChildSize: .9,
       maxChildSize: 1,
       minChildSize: .5,
+      useRootNavigator: false,
       builder: (controller) {
         return GenericListener<SuccessRateHolder>(
           valueListenable: ratesNotifier,

--- a/gallery/lib/templates/scaffolds/gt_confirmation_scaffold_usecase.dart
+++ b/gallery/lib/templates/scaffolds/gt_confirmation_scaffold_usecase.dart
@@ -361,6 +361,7 @@ class _ConfirmationScaffoldPreviewState
       initialChildSize: .9,
       maxChildSize: 1,
       minChildSize: .5,
+      useRootNavigator: false,
       builder: (controller) {
         return GtConfirmationScaffold(
           title: knobs.title,

--- a/gallery/lib/templates/scaffolds/gt_receipt_scaffold_usecase.dart
+++ b/gallery/lib/templates/scaffolds/gt_receipt_scaffold_usecase.dart
@@ -306,6 +306,7 @@ class _ReceiptScaffoldPreviewState extends State<_ReceiptScaffoldPreview>
       initialChildSize: .9,
       maxChildSize: 1,
       minChildSize: .5,
+      useRootNavigator: false,
       builder: (controller) {
         return GtReceiptScaffold(
           onClose: () => GtRouter.popView(),

--- a/gallery/pubspec.lock
+++ b/gallery/pubspec.lock
@@ -713,8 +713,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.0.41"
-      resolved-ref: "02057b459f164478ba6ed71847d72310ffb18a50"
+      ref: "v0.0.42"
+      resolved-ref: "1db92e0c3f54e565f6dadade46dd09dc54c48687"
       url: "https://github.com/gofinancials/gt_mobile_foundation.git"
     source: git
     version: "0.0.1"

--- a/gallery/pubspec.yaml
+++ b/gallery/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.41
+      ref: v0.0.42
   google_fonts: ^8.2.0
   # Gallery-only: rasterises the PDFs built by gt_mobile_ui so a use case can
   # show the document on screen. The suite itself ships no PDF viewer.

--- a/lib/common/router/gt_activity_route_observer.dart
+++ b/lib/common/router/gt_activity_route_observer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
 /// A [NavigatorObserver] that monitors navigation transitions and registers user
@@ -7,31 +8,33 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 /// Automatically captures route transitions (`didPush`, `didPop`, `didReplace`, `didRemove`)
 /// and updates the current active [RouteSettings] on [GtActivityState].
 ///
+/// This observer tracks activity only; the route history behind
+/// [GtRouter.currentRoute] is owned by [GtRouter.observer], which needs its own
+/// entry in the list.
+///
 /// ### Example:
 /// ```dart
 /// MaterialApp(
 ///   navigatorObservers: [
+///     GtRouter.observer,
 ///     GtActivityRouteObserver(activityState),
 ///   ],
 /// );
 /// ```
 class GtActivityRouteObserver extends NavigatorObserver {
-  final GtActivityState? _activityState;
+  final GtActivityState _activityState;
 
   /// Creates a [GtActivityRouteObserver].
   ///
   /// [activityState] is the target state model to register route transitions with.
-  GtActivityRouteObserver([this._activityState]);
+  GtActivityRouteObserver(this._activityState);
 
   GtActivityState? get _targetState => _activityState;
 
   void _onRouteActivity(Route<dynamic>? route) {
-    if (route == null) return;
-    final settings = route.settings;
-    if (settings.name != null) {
-      GtRouter.setCurrentRoute(settings.name!);
-    }
-    _targetState?.registerActivity(routeSettings: settings);
+    bool hasName = route?.settings.name?.hasValue ?? false;
+    if (!hasName) return;
+    _targetState?.registerActivity(routeSettings: route?.settings);
   }
 
   @override

--- a/lib/common/router/gt_route_observer.dart
+++ b/lib/common/router/gt_route_observer.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+
+/// A [NavigatorObserver] that derives the route history from the [Navigator]
+/// it is installed on, and backs [GtRouter]'s history getters.
+///
+/// Unlike a [GlobalKey], an observer's attachment follows the tree: Flutter
+/// installs it in the navigator's `initState` and detaches it in `deactivate`.
+/// A remounted app root therefore gets a live navigator and a history rebuilt
+/// from its own pushes, with nothing to reset by hand.
+///
+/// Because the history is *derived* rather than recorded by callers, it cannot
+/// drift from the navigator: routes pushed without going through [GtRouter],
+/// modal sheets, dialogs and multi-route pops are all accounted for.
+///
+/// Install it on the app's root navigator:
+///
+/// ```dart
+/// MaterialApp(
+///   navigatorObservers: [GtRouter.observer],
+/// );
+/// ```
+///
+/// Only one navigator may host a given observer instance at a time — Flutter
+/// asserts this on install — so do not pass [GtRouter.observer] to a nested
+/// [Navigator] as well.
+class GtRouteObserver extends NavigatorObserver with AppAnalyticsMixin {
+  /// Creates a route-history observer.
+  ///
+  /// Prefer the shared [GtRouter.observer] over constructing your own; a second
+  /// instance tracks its own history that [GtRouter] does not read.
+  GtRouteObserver();
+
+  final List<Route<dynamic>> _stack = [];
+
+  /// The navigator whose routes are currently in [_stack].
+  ///
+  /// Detaching does not pop anything, so the history has to be discarded
+  /// explicitly when the observer changes hands — otherwise a long-lived
+  /// instance carries the old tree's routes into the new one, which is the very
+  /// staleness this observer exists to avoid.
+  NavigatorState? _observed;
+
+  /// The route path most recently reported to analytics.
+  String? _trackedRoute;
+
+  void _syncAttachment() {
+    final current = navigator;
+    if (identical(current, _observed)) return;
+    _observed = current;
+    _stack.clear();
+    // A remounted tree navigates to its initial route again; that is a real
+    // screen view and must not be suppressed as a duplicate.
+    _trackedRoute = null;
+  }
+
+  /// Whether a report has been scheduled for the end of the current microtask.
+  bool _trackScheduled = false;
+
+  /// Reports the route now on top to analytics, if it changed.
+  ///
+  /// Called after every stack mutation rather than from [didPush] alone, so
+  /// that pops, replacements and removals — which reveal a different screen
+  /// without pushing anything — are tracked too.
+  ///
+  /// The report is deferred to a microtask so that a batch of synchronous
+  /// changes reports once, for the screen the user actually lands on. Otherwise
+  /// `popUntil` and `pushNamedAndRemoveUntil`, which report each removed route
+  /// individually, would log a screen view for every route they unwind past.
+  void _trackCurrentRoute() {
+    if (_trackScheduled) return;
+    _trackScheduled = true;
+    scheduleMicrotask(() {
+      _trackScheduled = false;
+      final route = currentRoute;
+      if (route == null || route == _trackedRoute) return;
+      _trackedRoute = route;
+      unawaited(trackNavigation(route));
+    });
+  }
+
+  /// The routes currently on the observed navigator, oldest first.
+  ///
+  /// Empty while the observer is not installed on a navigator.
+  List<Route<dynamic>> get stack {
+    _syncAttachment();
+    return List.unmodifiable(_stack);
+  }
+
+  /// The name of the route at the top of the observed navigator, if any.
+  ///
+  /// Routes pushed without a [RouteSettings.name] report `null`, except for
+  /// [PopupRoute]s — sheets and dialogs — which are reported against the route
+  /// they were opened over.
+  String? get currentRoute {
+    _syncAttachment();
+    return _stack.isEmpty ? null : _nameAt(_stack.length - 1);
+  }
+
+  /// Whether there is a route beneath the current one on the observed navigator.
+  bool get hasPreviousRoute {
+    _syncAttachment();
+    return _stack.length >= 2;
+  }
+
+  String? _nameAt(int index) {
+    final route = _stack[index];
+    final name = route.settings.name;
+    if (name.hasValue) return name;
+    // Sheets and dialogs are pushed without a name. Most are [PopupRoute]s, but
+    // `showCupertinoSheet` pushes a [CupertinoSheetRoute], which is a
+    // [PageRoute], so it has to be matched separately.
+    if ((route is PopupRoute || route is CupertinoSheetRoute) && index > 0) {
+      return "${_nameAt(index - 1)}?withmodal=true";
+    }
+    return null;
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _syncAttachment();
+    _stack.add(route);
+    _trackCurrentRoute();
+  }
+
+  // Pops and removals can target a route that is not on top — `popUntil` and
+  // `pushNamedAndRemoveUntil` both report each removed route individually — so
+  // entries are dropped by identity rather than from the end.
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    _syncAttachment();
+    _stack.remove(route);
+    _trackCurrentRoute();
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didRemove(route, previousRoute);
+    _syncAttachment();
+    _stack.remove(route);
+    _trackCurrentRoute();
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    _syncAttachment();
+    final index = oldRoute == null ? -1 : _stack.indexOf(oldRoute);
+    if (index < 0) {
+      if (newRoute != null) _stack.add(newRoute);
+    } else if (newRoute == null) {
+      _stack.removeAt(index);
+    } else {
+      _stack[index] = newRoute;
+    }
+    _trackCurrentRoute();
+  }
+}

--- a/lib/common/router/gt_router.dart
+++ b/lib/common/router/gt_router.dart
@@ -1,49 +1,106 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/common/router/gt_route_observer.dart';
 
 /// A centralized utility class for managing application routing and navigation.
 ///
-/// It provides convenience methods for common navigation actions and maintains
-/// an internal stack of route names to track the user's navigation history.
+/// It provides convenience methods for common navigation actions, and reads the
+/// user's navigation history from [observer] — install that on the app's root
+/// navigator for [currentRoute], [hasPreviousRoute] and [canPop] to work:
+///
+/// ```dart
+/// MaterialApp(
+///   navigatorObservers: [GtRouter.observer],
+/// );
+/// ```
 class GtRouter {
   GtRouter._();
 
-  static final List<String> _routeStack = [];
+  /// Observes the app's root navigator and owns the route history that
+  /// [currentRoute] and [hasPreviousRoute] read from.
+  ///
+  /// Because the observer is attached and detached by the navigator itself, the
+  /// history follows the tree's lifecycle: a remounted app root starts from an
+  /// empty history rather than inheriting the previous tree's.
+  static final GtRouteObserver observer = GtRouteObserver();
 
   /// A global key used to access the root [NavigatorState] without a [BuildContext].
+  @Deprecated(
+    'Install GtRouter.observer via MaterialApp.navigatorObservers instead. '
+    'A static GlobalKey reattaches the same NavigatorState when an app root is '
+    'remounted, so the new tree inherits the previous tree\'s route stack. '
+    'This key is only consulted when no observer is installed and will be '
+    'removed in a future release.',
+  )
   static GlobalKey<NavigatorState> navigatorKey = GlobalKey();
 
-  /// Returns the name of the current route at the top of the internal stack, if any.
-  static String? get currentRoute => _routeStack.tryLast;
+  /// Detaches the router from the tree that owned it: a fresh navigator key and
+  /// an empty route stack.
+  @Deprecated(
+    'Unnecessary once GtRouter.observer is installed — the observer detaches '
+    'itself with the tree, so there is nothing to reset. Will be removed '
+    'alongside navigatorKey.',
+  )
+  static void reset() {
+    navigatorKey = GlobalKey<NavigatorState>();
+    _legacyRouteStack.clear();
+  }
 
-  /// Whether there is a previous route in the internal navigation stack.
-  static bool get hasPreviousRoute => _routeStack.length >= 2;
+  /// Returns the name of the route at the top of the navigator, if any.
+  static String? get currentRoute =>
+      observer.navigator == null ? _legacyRouteStack.tryLast : observer.currentRoute;
+
+  /// Whether there is a route beneath the current one.
+  static bool get hasPreviousRoute => observer.navigator == null
+      ? _legacyRouteStack.length >= 2
+      : observer.hasPreviousRoute;
+
+  static final List<String> _legacyRouteStack = [];
 
   /// Adds the given [route] name to the internal route stack.
+  @Deprecated(
+    'The route history is derived from GtRouter.observer; recording routes by '
+    'hand lets it drift from the navigator. This is a no-op once the observer '
+    'is installed.',
+  )
   static void setCurrentRoute(String route) {
-    _routeStack.add(route);
+    if (observer.navigator != null) return;
+    _legacyRouteStack.add(route);
   }
 
   /// Records that a modal has been opened on top of the current route.
   ///
   /// Optionally takes a [title] to provide more context in the route stack logging.
+  @Deprecated(
+    'GtRouter.observer records modal routes as they are pushed. This is a '
+    'no-op once the observer is installed.',
+  )
   static void openedModal([String? title]) {
     AppLogger.info("OPENING A MODAL IN: $currentRoute");
-    _routeStack.add(
+    if (observer.navigator != null) return;
+    _legacyRouteStack.add(
       "${title.hasValue ? "$title->" : ''}$currentRoute?withmodal=true",
     );
   }
 
   /// Removes the last recorded route or modal entry from the internal route stack.
+  @Deprecated(
+    'GtRouter.observer records pops as they happen. This is a no-op once the '
+    'observer is installed.',
+  )
   static void removeLastRoute() {
-    if (_routeStack.isEmpty) return;
-    _routeStack.removeLast();
+    if (observer.navigator != null) return;
+    if (_legacyRouteStack.isEmpty) return;
+    _legacyRouteStack.removeLast();
   }
 
-  /// Helper to get the [NavigatorState] either from the given [context] or the [navigatorKey].
+  /// Helper to get the [NavigatorState] either from the given [context] or the
+  /// installed [observer], falling back to the deprecated [navigatorKey].
   static NavigatorState? _navigator(BuildContext? context) {
-    return context == null ? navigatorKey.currentState : Navigator.of(context);
+    if (context != null) return Navigator.of(context);
+    // ignore: deprecated_member_use_from_same_package
+    return observer.navigator ?? navigatorKey.currentState;
   }
 
   /// Returns whether there is a valid route to pop to.
@@ -52,9 +109,6 @@ class GtRouter {
   /// Otherwise, it checks using the global [navigatorKey].
   static bool canPop([BuildContext? context]) {
     if (!hasPreviousRoute) return false;
-    if (context == null) {
-      return navigatorKey.currentState?.canPop() ?? false;
-    }
     return _navigator(context)?.canPop() ?? false;
   }
 

--- a/lib/common/router/gt_router.dart
+++ b/lib/common/router/gt_router.dart
@@ -48,8 +48,9 @@ class GtRouter {
   }
 
   /// Returns the name of the route at the top of the navigator, if any.
-  static String? get currentRoute =>
-      observer.navigator == null ? _legacyRouteStack.tryLast : observer.currentRoute;
+  static String? get currentRoute => observer.navigator == null
+      ? _legacyRouteStack.tryLast
+      : observer.currentRoute;
 
   /// Whether there is a route beneath the current one.
   static bool get hasPreviousRoute => observer.navigator == null

--- a/lib/common/router/router.dart
+++ b/lib/common/router/router.dart
@@ -1,2 +1,3 @@
 export 'gt_activity_route_observer.dart';
+export 'gt_route_observer.dart';
 export 'gt_router.dart';

--- a/lib/widgets/molecules/inputs/gt_date_field.dart
+++ b/lib/widgets/molecules/inputs/gt_date_field.dart
@@ -152,6 +152,7 @@ class _GtDateFieldState extends State<GtDateField> with GtBottomSheetMixin {
     if (!widget.isEnabled) return;
     showDraggableSheet(
       context,
+      useRootNavigator: false,
       builder: (controller) => GtCalendarModal(
         controller,
         controller: _calendarController,

--- a/lib/widgets/molecules/inputs/gt_drowpdown_field.dart
+++ b/lib/widgets/molecules/inputs/gt_drowpdown_field.dart
@@ -152,6 +152,7 @@ class _GtDropdownFieldState<T> extends State<GtDropdownField<T>>
     if (!widget.isEnabled) return;
     showDraggableSheet(
       context,
+      useRootNavigator: false,
       builder: (scrollController) => GtDropDownModal(
         autoFocus: widget.autoFocus,
         scrollController,

--- a/lib/widgets/molecules/inputs/gt_phone_field.dart
+++ b/lib/widgets/molecules/inputs/gt_phone_field.dart
@@ -291,6 +291,7 @@ class _GtCountryCodeFieldState extends State<GtCountryCodeField>
     if (!widget.isEnabled) return;
     showDraggableSheet(
       context,
+      useRootNavigator: false,
       builder: (scrollController) => GtDropDownModal<Country>(
         autoFocus: true,
         scrollController,

--- a/lib/widgets/molecules/inputs/gt_transfer_field.dart
+++ b/lib/widgets/molecules/inputs/gt_transfer_field.dart
@@ -643,6 +643,7 @@ class _GtTransferCategoryFieldState extends State<GtTransferCategoryField>
     );
     showDraggableSheet(
       context,
+      useRootNavigator: false,
       builder: (scrollController) => GtDropDownModal<GtTransactionCategory>(
         autoFocus: true,
         scrollController,

--- a/lib/widgets/templates/data_viz/gt_line_chart_container.dart
+++ b/lib/widgets/templates/data_viz/gt_line_chart_container.dart
@@ -118,6 +118,7 @@ class GtLineChartContainer extends GtStatelessWidget with GtBottomSheetMixin {
   void _showCalendar(BuildContext context) {
     showDraggableSheet(
       context,
+      useRootNavigator: false,
       builder: (scrollController) => GtCalendarModal(
         scrollController,
         controller: controller,

--- a/lib/widgets/templates/dialogs/gt_confirm_dialog.dart
+++ b/lib/widgets/templates/dialogs/gt_confirm_dialog.dart
@@ -129,7 +129,6 @@ mixin GtConfirmDialogMixin {
       barrierDismissible: isDismissable,
       useRootNavigator: true,
       builder: (context) {
-        GtRouter.openedModal();
         return GtConfirmDialog(
           key: ValueKey((title, allowText, denyText, description)),
           title: title,

--- a/lib/widgets/templates/modals/gt_bottom_sheet.dart
+++ b/lib/widgets/templates/modals/gt_bottom_sheet.dart
@@ -73,6 +73,12 @@ class GtBottomSheet<T> {
   final bool canDragToClose;
 
   /// Whether the sheet should be pushed onto the root navigator instead of the nested one.
+  ///
+  /// Keep this `true` for [GtRouter.currentRoute] to see the sheet; a sheet
+  /// pushed onto a nested navigator is invisible to [GtRouter.observer].
+  ///
+  /// Ignored for non-draggable, non-floating sheets on iOS, which are presented
+  /// with [showCupertinoSheet] and always target the root navigator.
   final bool useRootNavigator;
 
   /// Internal flag tracking if the sheet is in draggable mode.
@@ -96,7 +102,6 @@ class GtBottomSheet<T> {
   /// [Future] that resolves to the value `T` passed when popping the sheet.
   Future<T?> present(BuildContext context) async {
     GtOverlay.closeCurrentOverlays();
-    GtRouter.openedModal();
     if (!context.isMobile) return _presentDesktopSheet(context);
     return _presentMobileSheet(context);
   }
@@ -139,10 +144,14 @@ class GtBottomSheet<T> {
     );
 
     if ((!_isDraggable && !floating) && context.isIos) {
+      // `useRootNavigator` has no equivalent here: `showCupertinoSheet` always
+      // pushes onto the root navigator. It must not be forwarded as
+      // `useNestedNavigation`, which is unrelated — that flag gives the sheet
+      // its own nested [Navigator], hiding any route pushed inside it from the
+      // root navigator's observers.
       return showCupertinoSheet<T>(
         context: context,
         builder: (context) => child,
-        useNestedNavigation: useRootNavigator,
         enableDrag: canDragToClose,
         showDragHandle: canDragToClose,
       );

--- a/lib/widgets/templates/modals/mixins/gt_modals_mixins.dart
+++ b/lib/widgets/templates/modals/mixins/gt_modals_mixins.dart
@@ -12,6 +12,7 @@ mixin GtBottomModalMixin {
     required String title,
     String? description,
     AppImageData? icon,
+    bool useRootNavigator = true,
   }) {
     _showModal(
       context,
@@ -24,13 +25,18 @@ mixin GtBottomModalMixin {
         ),
         alignment: context.isMobile ? .bottomCenter : .center,
       ),
+      useRootNavigator: useRootNavigator,
     );
   }
 
   /// Displays a simple bottom modal with a [title], an optional [description], and an optional [icon].
   ///
   /// The modal adapts its alignment based on the platform (bottom center on mobile, center elsewhere).
-  void showBottomModalWithChild(BuildContext context, {required Widget child}) {
+  void showBottomModalWithChild(
+    BuildContext context, {
+    required Widget child,
+    bool useRootNavigator = true,
+  }) {
     _showModal(
       context,
       modal: GtBottomModal.child(
@@ -38,6 +44,7 @@ mixin GtBottomModalMixin {
         alignment: context.isMobile ? .bottomCenter : .center,
         child: child,
       ),
+      useRootNavigator: useRootNavigator,
     );
   }
 
@@ -47,12 +54,14 @@ mixin GtBottomModalMixin {
   void showTaskBottomModal(
     BuildContext context, {
     required GtBottomModalController controller,
+    bool useRootNavigator = true,
   }) {
     final title = controller.title;
     final description = controller.description;
 
     _showModal(
       context,
+      useRootNavigator: useRootNavigator,
       modal: GtBottomModal.controller(
         key: ValueKey((title, "gt-controlled-bottom-modal", description)),
         controller: controller,
@@ -65,13 +74,16 @@ mixin GtBottomModalMixin {
   ///
   /// On non-mobile platforms, it uses [showAdaptiveDialog]. On mobile platforms,
   /// it uses [showModalBottomSheet].
-  void _showModal(BuildContext context, {required Widget modal}) {
+  void _showModal(
+    BuildContext context, {
+    required Widget modal,
+    bool useRootNavigator = true,
+  }) {
     GtOverlay.closeCurrentOverlays();
-    GtRouter.openedModal();
 
     if (!context.isMobile) {
       showAdaptiveDialog(
-        useRootNavigator: false,
+        useRootNavigator: useRootNavigator,
         context: context,
         anchorPoint: Offset(context.width * .5, context.height * .5),
         barrierDismissible: false,
@@ -83,7 +95,7 @@ mixin GtBottomModalMixin {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      useRootNavigator: false,
+      useRootNavigator: useRootNavigator,
       isDismissible: false,
       enableDrag: false,
       backgroundColor: Colors.transparent,
@@ -108,7 +120,7 @@ mixin GtBottomSheetMixin {
     bool isScrollable = false,
     bool canPop = true,
     bool floating = false,
-    bool useRootNavigator = false,
+    bool useRootNavigator = true,
     double maxHeightFraction = .9,
   }) async {
     return GtBottomSheet<T>(
@@ -136,7 +148,7 @@ mixin GtBottomSheetMixin {
     double minChildSize = .3,
     double initialChildSize = .7,
     double maxChildSize = .9,
-    bool useRootNavigator = false,
+    bool useRootNavigator = true,
     bool floating = false,
     double maxHeightFraction = .9,
   }) async {

--- a/lib/widgets/templates/nav_aware/gt_pop_scope.dart
+++ b/lib/widgets/templates/nav_aware/gt_pop_scope.dart
@@ -20,7 +20,7 @@ class _GtRootPopScopeState extends State<GtRootPopScope>
         canPop: false,
         onPopInvokedWithResult: (_, value) {
           confirmAction(
-            GtRouter.navigatorKey.currentContext ?? context,
+            GtRouter.observer.navigator?.context ?? context,
             onContinue: GtRouter.closeApp,
             title: "closeApp".tr(),
             description: "closeAppQuestion".tr(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   gt_mobile_foundation:
     git:
       url: https://github.com/gofinancials/gt_mobile_foundation.git
-      ref: v0.0.41
+      ref: v0.0.42
   lottie: ^3.0.0
   pin_code_fields: ^9.3.0
   shimmer: ^3.0.0

--- a/test/gt_router_test.dart
+++ b/test/gt_router_test.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart' show showCupertinoSheet;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/common/router/gt_route_observer.dart';
+import 'package:gt_mobile_ui/common/router/gt_router.dart';
+
+/// Mounts a root wired the way a consuming app is, using the shared observer.
+Widget _app({String initialRoute = '/home'}) {
+  return MaterialApp(
+    navigatorObservers: [GtRouter.observer],
+    initialRoute: initialRoute,
+    routes: {
+      '/home': (_) => const Scaffold(body: Text('home')),
+      '/details': (_) => const Scaffold(body: Text('details')),
+      '/summary': (_) => const Scaffold(body: Text('summary')),
+    },
+  );
+}
+
+/// Captures the navigation paths the observer reports through [AppAnalyticsMixin].
+class _FakeAnalyticsService implements AppAnalyticsService {
+  final List<String> navigations = [];
+
+  @override
+  Future<void> trackNavigation(String path, {String? widgetClass}) async {
+    navigations.add(path);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('GtRouteObserver analytics', () {
+    late _FakeAnalyticsService analytics;
+
+    setUp(() {
+      analytics = _FakeAnalyticsService();
+      if (locator.isRegistered<AppAnalyticsService>()) {
+        locator.unregister<AppAnalyticsService>();
+      }
+      locator.registerSingleton<AppAnalyticsService>(analytics);
+    });
+
+    tearDown(() => locator.unregister<AppAnalyticsService>());
+
+    testWidgets('reports the initial route and each subsequent screen', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app());
+      expect(analytics.navigations, ['/home']);
+
+      unawaited(GtRouter.pushNamed('/details'));
+      await tester.pumpAndSettle();
+      expect(analytics.navigations, ['/home', '/details']);
+
+      // A pop reveals a screen without pushing one; it still counts as a view.
+      GtRouter.forcePopView();
+      await tester.pumpAndSettle();
+      expect(analytics.navigations, ['/home', '/details', '/home']);
+    });
+
+    testWidgets('reports a modal as its own screen', (tester) async {
+      await tester.pumpWidget(_app());
+
+      showModalBottomSheet<void>(
+        context: GtRouter.observer.navigator!.context,
+        builder: (_) => const SizedBox(height: 100),
+      );
+      await tester.pumpAndSettle();
+
+      expect(analytics.navigations, ['/home', '/home?withmodal=true']);
+    });
+
+    testWidgets('reports once for a multi-route pop', (tester) async {
+      await tester.pumpWidget(_app());
+      unawaited(GtRouter.pushNamed('/details'));
+      await tester.pumpAndSettle();
+      unawaited(GtRouter.pushNamed('/summary'));
+      await tester.pumpAndSettle();
+      analytics.navigations.clear();
+
+      // popToFirst removes /summary and /details; only /home becomes visible,
+      // so the intermediate removal must not be reported as a screen view.
+      GtRouter.popToFirst();
+      await tester.pumpAndSettle();
+
+      expect(analytics.navigations, ['/home']);
+    });
+
+    testWidgets('reports the initial route again after a remount', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app());
+      expect(analytics.navigations, ['/home']);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(_app());
+
+      expect(analytics.navigations, ['/home', '/home']);
+    });
+  });
+
+  group('GtRouteObserver', () {
+    testWidgets('derives the history from the navigator', (tester) async {
+      await tester.pumpWidget(_app());
+
+      expect(GtRouter.currentRoute, '/home');
+      expect(GtRouter.hasPreviousRoute, isFalse);
+      expect(GtRouter.canPop(), isFalse);
+
+      unawaited(GtRouter.pushNamed('/details'));
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.currentRoute, '/details');
+      expect(GtRouter.hasPreviousRoute, isTrue);
+      expect(GtRouter.canPop(), isTrue);
+
+      GtRouter.forcePopView();
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.currentRoute, '/home');
+      expect(GtRouter.hasPreviousRoute, isFalse);
+    });
+
+    testWidgets('tracks routes pushed without going through GtRouter', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app());
+      final navigator = GtRouter.observer.navigator!;
+
+      navigator.push(
+        MaterialPageRoute(
+          settings: const RouteSettings(name: '/adhoc'),
+          builder: (_) => const Scaffold(body: Text('adhoc')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.currentRoute, '/adhoc');
+      expect(GtRouter.hasPreviousRoute, isTrue);
+    });
+
+    testWidgets('reports a modal against the route it was opened over', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app());
+
+      showModalBottomSheet<void>(
+        context: GtRouter.observer.navigator!.context,
+        builder: (_) => const SizedBox(height: 100),
+      );
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.currentRoute, '/home?withmodal=true');
+      expect(GtRouter.hasPreviousRoute, isTrue);
+
+      GtRouter.forcePopView();
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.currentRoute, '/home');
+      expect(GtRouter.hasPreviousRoute, isFalse);
+    });
+
+    testWidgets('reports a cupertino sheet as a modal', (tester) async {
+      // CupertinoSheetRoute is a PageRoute, not a PopupRoute, so it needs its
+      // own case in the naming fallback.
+      await tester.pumpWidget(_app());
+
+      unawaited(
+        showCupertinoSheet<void>(
+          context: GtRouter.observer.navigator!.context,
+          builder: (_) => const SizedBox(height: 100),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.currentRoute, '/home?withmodal=true');
+      expect(GtRouter.hasPreviousRoute, isTrue);
+    });
+
+    testWidgets('drops every route removed by a multi-route pop', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app());
+
+      unawaited(GtRouter.pushNamed('/details'));
+      await tester.pumpAndSettle();
+      unawaited(GtRouter.pushNamed('/summary'));
+      await tester.pumpAndSettle();
+      expect(GtRouter.observer.stack, hasLength(3));
+
+      GtRouter.popToFirst();
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.observer.stack, hasLength(1));
+      expect(GtRouter.currentRoute, '/home');
+      expect(GtRouter.hasPreviousRoute, isFalse);
+    });
+
+    testWidgets('follows a replacement in place', (tester) async {
+      await tester.pumpWidget(_app());
+      unawaited(GtRouter.pushNamed('/details'));
+      await tester.pumpAndSettle();
+
+      GtRouter.pushReplacementNamed('/summary');
+      await tester.pumpAndSettle();
+
+      expect(GtRouter.observer.stack, hasLength(2));
+      expect(GtRouter.currentRoute, '/summary');
+    });
+
+    testWidgets('a remounted root does not inherit the previous history', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app());
+      unawaited(GtRouter.pushNamed('/details'));
+      await tester.pumpAndSettle();
+
+      showModalBottomSheet<void>(
+        context: GtRouter.observer.navigator!.context,
+        builder: (_) => const SizedBox(height: 100),
+      );
+      await tester.pumpAndSettle();
+
+      final firstNavigator = GtRouter.observer.navigator;
+      expect(GtRouter.observer.stack, hasLength(3));
+
+      // Unmount and mount a fresh root, the way a per-journey E2E suite does.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(_app());
+
+      expect(GtRouter.observer.navigator, isNotNull);
+      expect(GtRouter.observer.navigator, isNot(same(firstNavigator)));
+      expect(GtRouter.observer.stack, hasLength(1));
+      expect(GtRouter.currentRoute, '/home');
+      expect(GtRouter.hasPreviousRoute, isFalse);
+      expect(GtRouter.canPop(), isFalse);
+    });
+
+    testWidgets('detaches from the tree when the navigator goes away', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_app());
+      expect(GtRouter.observer.navigator, isNotNull);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(GtRouter.observer.navigator, isNull);
+      expect(GtRouter.currentRoute, isNull);
+      expect(GtRouter.hasPreviousRoute, isFalse);
+    });
+
+    test('a fresh observer starts empty', () {
+      final observer = GtRouteObserver();
+
+      expect(observer.navigator, isNull);
+      expect(observer.stack, isEmpty);
+      expect(observer.currentRoute, isNull);
+      expect(observer.hasPreviousRoute, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description

- **Purpose:** Fix bug/Refactor
- **Issue Link:** #157
- **Summary:** Replaces `GtRouter`'s static `GlobalKey` + hand-recorded route
  stack with a `NavigatorObserver` that derives the route history from the
  navigator itself, and wires navigation tracking into it via `AppAnalyticsMixin`.

  A `static GlobalKey` reattaches the *same* `NavigatorState` when an app root is
  remounted, so a new tree inherited the previous tree's route stack — including
  any open bottom sheet — while `_routeStack` kept a history that no longer
  matched the screen. `currentRoute`, `hasPreviousRoute` and therefore
  `GtBackButton(routeStackSensitive: true)` all read from that stale history.

  A `NavigatorObserver`'s attachment follows the tree — Flutter installs it in the
  navigator's `initState` and detaches it in `deactivate` — so a remounted root
  gets a live navigator and a history rebuilt from its own pushes. Because the
  history is *derived* rather than recorded by callers, it also can't drift from
  the navigator: routes pushed without going through `GtRouter`, modals, and
  multi-route pops are all accounted for.

  **Consumer migration required.** Apps must add `GtRouter.observer` to their
  `MaterialApp.navigatorObservers`. Until they do, they fall through to the
  deprecated `navigatorKey` path and keep the old behaviour — nothing breaks, but
  the fix isn't active. `onebank_personal` can then drop its `reset()` drain-loop
  workaround.

  ```dart
  MaterialApp(
    navigatorObservers: [GtRouter.observer, GtActivityRouteObserver(activityState)],
  )
  ```

### Key changes

- **New `GtRouteObserver`** (`lib/common/router/gt_route_observer.dart`) — owns the
  route history; removes by identity so `popUntil` / `pushNamedAndRemoveUntil`
  unwind correctly; discards its stack when it changes navigators; names unnamed
  modal routes against the route they were opened over.
- **`GtRouter`** — `currentRoute` / `hasPreviousRoute` now read from `observer`;
  `navigatorKey`, `reset()`, `setCurrentRoute()`, `openedModal()` and
  `removeLastRoute()` are `@Deprecated` and inert once the observer is installed.
- **Analytics** — `GtRouteObserver` mixes in `AppAnalyticsMixin` and reports each
  screen the user lands on through `trackNavigation`, including back-navigation and
  modals. Reports are coalesced into a microtask so a `popUntil` logs one screen
  view for where the user lands, not one per route it unwinds past.
- **`GtActivityRouteObserver`** — no longer calls `GtRouter.setCurrentRoute`. That
  path was itself buggy: `didPop` fed the *previous* route back through an
  **append**, so the stack grew on every pop.
- **Bug fix in `GtBottomSheet`** — `showCupertinoSheet` was being passed
  `useNestedNavigation: useRootNavigator`. Those flags are unrelated:
  `showCupertinoSheet` has no `useRootNavigator` parameter and always targets the
  root navigator, while `useNestedNavigation` gives the sheet its own inner
  `Navigator`. Every non-draggable, non-floating iOS sheet was silently getting
  nested navigation, and `useRootNavigator: false` did the opposite of what its
  name promised.
- **Modal mixins** — `useRootNavigator` threaded through `_showModal`, defaulting to
  `true` so modals are visible to the observer. Internal pickers (date, dropdown,
  phone, transfer, line chart) are pinned to `false` to preserve their behaviour.
- **Deps** — `gt_mobile_foundation` v0.0.41 → v0.0.42.

## ✨ Type of Change

- [x] ✨ New Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [ ] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)

- N/A — no visual changes.

## 🧪 How Has This Been Tested?

- [x] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated
- [ ] Manual Testing (Describe steps below)

New `test/gt_router_test.dart` (13 cases):

- History derived from the navigator; routes pushed without `GtRouter` tracked.
- Modal naming for `ModalBottomSheetRoute` and `CupertinoSheetRoute` — the latter
  extends `PageRoute`, not `PopupRoute`, so it needs its own case.
- `popToFirst` drops every unwound route; `pushReplacementNamed` replaces in place.
- **Remount isolation** — mount → open a sheet → unmount → remount yields a fresh
  navigator and an empty history. This is the regression test for #157.
- Observer detaches when the navigator goes away.
- Analytics: initial route, back-navigation, modals, one report per multi-route
  pop, and re-reporting the initial route after a remount.

## 📋 Checklist

- [x] `flutter analyze` passes locally (`lib`, `test`, `gallery/lib` — no issues).
- [x] `flutter test` passes (177/177 green).
- [x] `dart format` applied.
- [x] No unused code.
- [ ] Verified UI on small/large screens — N/A, no UI changes.
