### PR TITLE
180 add gtsignaturepad no primitive for capturing a drawn signature

### DIFF
--- a/.github/workflows/deploy_gallery.yaml
+++ b/.github/workflows/deploy_gallery.yaml
@@ -12,11 +12,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-# Allow one concurrent deployment, skipping runs queued behind an in-progress run.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/gallery/lib/main.directories.g.dart
+++ b/gallery/lib/main.directories.g.dart
@@ -76,6 +76,8 @@ import 'package:gallery/molecules/buttons/gt_icon_button_usecase.dart'
     as _gallery_molecules_buttons_gt_icon_button_usecase;
 import 'package:gallery/molecules/buttons/gt_outline_button_usecase.dart'
     as _gallery_molecules_buttons_gt_outline_button_usecase;
+import 'package:gallery/molecules/buttons/gt_question_text_button_usecase.dart'
+    as _gallery_molecules_buttons_gt_question_text_button_usecase;
 import 'package:gallery/molecules/buttons/gt_raised_button_usecase.dart'
     as _gallery_molecules_buttons_gt_raised_button_usecase;
 import 'package:gallery/molecules/buttons/gt_text_button_usecase.dart'
@@ -766,6 +768,17 @@ final directories = <_widgetbook.WidgetbookNode>[
                     builder:
                         _gallery_molecules_buttons_gt_outline_button_usecase
                             .playgroundGtOutlineButtonUseCase,
+                  ),
+                ],
+              ),
+              _widgetbook.WidgetbookComponent(
+                name: 'GtQuestionTextButton',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'GtQuestionTextButton',
+                    builder:
+                        _gallery_molecules_buttons_gt_question_text_button_usecase
+                            .playgroundGtQuestionTextButtonUseCase,
                   ),
                 ],
               ),

--- a/gallery/lib/main.directories.g.dart
+++ b/gallery/lib/main.directories.g.dart
@@ -114,6 +114,8 @@ import 'package:gallery/molecules/inputs/gt_pin_input_usecase.dart'
     as _gallery_molecules_inputs_gt_pin_input_usecase;
 import 'package:gallery/molecules/inputs/gt_search_field_usecase.dart'
     as _gallery_molecules_inputs_gt_search_field_usecase;
+import 'package:gallery/molecules/inputs/gt_signature_pad_usecase.dart'
+    as _gallery_molecules_inputs_gt_signature_pad_usecase;
 import 'package:gallery/molecules/inputs/gt_text_field_usecase.dart'
     as _gallery_molecules_inputs_gt_text_field_usecase;
 import 'package:gallery/molecules/inputs/gt_transfer_field_usecase.dart'
@@ -972,6 +974,18 @@ final directories = <_widgetbook.WidgetbookNode>[
                     name: 'GtSearchField',
                     builder: _gallery_molecules_inputs_gt_search_field_usecase
                         .playgroundGtSearchFieldUseCase,
+                  ),
+                ],
+              ),
+              _widgetbook.WidgetbookComponent(
+                name: 'GtSignaturePad',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'GtSignaturePad',
+                    builder: _gallery_molecules_inputs_gt_signature_pad_usecase
+                        .playgroundGtSignaturePadUseCase,
+                    designLink:
+                        'https://www.figma.com/design/EE0KNJdpCKsQGoLFyLrC2v/Personal?node-id=5838-32397&m=dev',
                   ),
                 ],
               ),

--- a/gallery/lib/molecules/buttons/buttons.dart
+++ b/gallery/lib/molecules/buttons/buttons.dart
@@ -4,5 +4,6 @@ export 'gt_cancel_button_usecase.dart';
 export 'gt_help_button_usecase.dart';
 export 'gt_icon_button_usecase.dart';
 export 'gt_outline_button_usecase.dart';
+export 'gt_question_text_button_usecase.dart';
 export 'gt_raised_button_usecase.dart';
 export 'gt_text_button_usecase.dart';

--- a/gallery/lib/molecules/buttons/gt_question_text_button_usecase.dart
+++ b/gallery/lib/molecules/buttons/gt_question_text_button_usecase.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:gallery/lib.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'GtQuestionTextButton',
+  type: GtQuestionTextButton,
+)
+Widget playgroundGtQuestionTextButtonUseCase(BuildContext context) {
+  final question = context.knobs.string(
+    label: 'Question Text',
+    initialValue: "Don't have an account?",
+  );
+  final action = context.knobs.string(
+    label: 'Action Text',
+    initialValue: 'Sign Up',
+  );
+  final (questionStyleName, questionStyle) =
+      context.knobs.object.dropdown<(String, TextStyle?)>(
+    label: 'Question Style',
+    initialOption: ('Default', null),
+    options: [
+      ('Default', null),
+      ('bodyS', context.textStyles.bodyS()),
+      ('bodyM', context.textStyles.bodyM()),
+      ('subHeadS', context.textStyles.subHeadS()),
+      ('labelM', context.textStyles.labelM()),
+    ],
+    labelBuilder: (v) => v.$1,
+  );
+  final (actionStyleName, actionStyle) =
+      context.knobs.object.dropdown<(String, TextStyle?)>(
+    label: 'Action Style',
+    initialOption: ('Default', null),
+    options: [
+      ('Default', null),
+      (
+        'subHeadS (Primary)',
+        context.textStyles.subHeadS(color: context.palette.primary.base)
+      ),
+      ('h6', context.textStyles.h6()),
+      (
+        'bodyM Bold',
+        context.textStyles.bodyM().copyWith(fontWeight: FontWeight.bold)
+      ),
+      (
+        'labelM Underline',
+        context.textStyles.labelM(decoration: TextDecoration.underline)
+      ),
+    ],
+    labelBuilder: (v) => v.$1,
+  );
+  final textAlign = context.knobs.objectOrNull.dropdown<TextAlign?>(
+    label: 'Text Align',
+    initialOption: null,
+    options: const [
+      null,
+      TextAlign.start,
+      TextAlign.center,
+      TextAlign.end,
+    ],
+    labelBuilder: (v) => v?.name ?? 'Default (Center)',
+  );
+
+  final qStyleParam = questionStyle == null
+      ? ''
+      : '\n  questionStyle: context.textStyles.$questionStyleName(),';
+  final aStyleParam = actionStyle == null
+      ? ''
+      : '\n  actionStyle: context.textStyles.$actionStyleName,';
+  final alignParam = textAlign == null
+      ? ''
+      : '\n  textAlign: TextAlign.${textAlign.name},';
+
+  final codeSnippet = '''
+GtQuestionTextButton(
+  "$question",
+  action: "$action",$qStyleParam$aStyleParam$alignParam
+  onPressed: () {},
+)''';
+
+  return GtWidgetDocPage(
+    title: 'GtQuestionTextButton',
+    description: '''
+<b>GtQuestionTextButton</b> is an interactive text button combining a question or prompt with a prominent action link.
+Commonly used at the bottom of authentication forms and onboarding flows (e.g. <i>"Don't have an account? Sign Up"</i>).''',
+    code: codeSnippet,
+    child: Center(
+      child: GtQuestionTextButton(
+        question,
+        action: action,
+        questionStyle: questionStyle,
+        actionStyle: actionStyle,
+        textAlign: textAlign,
+        onPressed: () {},
+      ),
+    ),
+  );
+}

--- a/gallery/lib/molecules/inputs/gt_search_field_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_search_field_usecase.dart
@@ -6,13 +6,17 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 @widgetbook.UseCase(name: 'GtSearchField', type: GtSearchField)
 Widget playgroundGtSearchFieldUseCase(BuildContext context) {
+  final isActionMode = context.knobs.boolean(
+    label: "Action Mode (forAction)",
+    initialValue: false,
+  );
   final hintText = context.knobs.string(
     label: "Hint Text",
-    initialValue: "Search here...",
+    initialValue: "Search transactions, beneficiaries...",
   );
   final autoFocus = context.knobs.boolean(
-    label: "Auto Focus",
-    initialValue: true,
+    label: "Auto Focus (Standard)",
+    initialValue: false,
   );
   final isEnabled = context.knobs.boolean(label: "Enabled", initialValue: true);
   final isRequired = context.knobs.boolean(
@@ -23,38 +27,74 @@ Widget playgroundGtSearchFieldUseCase(BuildContext context) {
     label: "Helper Text",
     initialValue: "",
   );
+  final useHero = context.knobs.boolean(
+    label: "Use Hero Animation Tag",
+    initialValue: false,
+  );
   final decoration = context.knobs.object.dropdown<(String, GtInputDecoration)>(
     label: 'Input Style',
     options: context.inputStyles.all,
-    initialOption: context.inputStyles.all.first,
+    initialOption: context.inputStyles.all[5],
     labelBuilder: (v) => v.$1,
   );
 
-  final codeSnippet =
-      '''
+  final heroTag = useHero ? 'search_bar_hero' : null;
+  final helperParam = helperText.isNotEmpty
+      ? '\n  helperText: "$helperText",'
+      : '';
+  final heroParam = heroTag != null ? '\n  heroTag: "$heroTag",' : '';
+
+  final codeSnippet = isActionMode
+      ? '''
+GtSearchField.forAction(
+  hintText: "$hintText",
+  isEnabled: $isEnabled,
+  isRequired: $isRequired,$helperParam$heroParam
+  onTap: () {
+    // Navigate to dedicated search screen
+  },
+)'''
+      : '''
 GtSearchField(
   controller: GtInputController(),
   hintText: "$hintText",
   autoFocus: $autoFocus,
   isEnabled: $isEnabled,
-  isRequired: $isRequired,
-  helperText: ${helperText.isEmpty ? "null" : '"$helperText"'},
-  decoration: /* Selected: ${decoration.$1} */,
+  isRequired: $isRequired,$helperParam
+  onChange: (value) {},
 )''';
 
   return GtWidgetDocPage(
     title: 'GtSearchField',
-    description:
-        'A specialized text input field designed specifically for search functionality.',
+    description: '''
+<b>GtSearchField</b> is a specialized text input field designed specifically for search queries.
+It supports both direct inline editing and an action-only mode (<b>GtSearchField.forAction</b>) that triggers callbacks (e.g. opening search overlays or route transitions with Hero support).''',
     code: codeSnippet,
-    child: GtSearchField(
-      controller: GtInputController(),
-      hintText: hintText.isEmpty ? null : hintText,
-      autoFocus: autoFocus,
-      isEnabled: isEnabled,
-      isRequired: isRequired,
-      helperText: helperText.isEmpty ? null : helperText,
-      decoration: decoration.$2,
-    ),
+    child: isActionMode
+        ? GtSearchField.forAction(
+            hintText: hintText.isEmpty ? null : hintText,
+            isEnabled: isEnabled,
+            isRequired: isRequired,
+            helperText: helperText.isEmpty ? null : helperText,
+            decoration: decoration.$2,
+            heroTag: heroTag,
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Search action triggered (onTap)'),
+                  duration: Duration(seconds: 1),
+                ),
+              );
+            },
+          )
+        : GtSearchField(
+            controller: GtInputController(),
+            hintText: hintText.isEmpty ? null : hintText,
+            autoFocus: autoFocus,
+            isEnabled: isEnabled,
+            isRequired: isRequired,
+            helperText: helperText.isEmpty ? null : helperText,
+            decoration: decoration.$2,
+          ),
   );
 }

--- a/gallery/lib/molecules/inputs/gt_signature_pad_usecase.dart
+++ b/gallery/lib/molecules/inputs/gt_signature_pad_usecase.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:gallery/lib.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'GtSignaturePad',
+  type: GtSignaturePad,
+  designLink:
+      'https://www.figma.com/design/EE0KNJdpCKsQGoLFyLrC2v/Personal?node-id=5838-32397&m=dev',
+)
+Widget playgroundGtSignaturePadUseCase(BuildContext context) {
+  final title = context.knobs.string(
+    label: 'Title',
+    initialValue: 'Tap to draw your signature',
+  );
+  final subtitle = context.knobs.string(
+    label: 'Subtitle',
+    initialValue: 'Use your finger or a stylus to sign here',
+  );
+  final height = context.knobs.double.slider(
+    label: 'Height',
+    initialValue: GtSignaturePad.defaultHeight,
+    min: 160,
+    max: 320,
+  );
+  final strokeWidth = context.knobs.double.slider(
+    label: 'Stroke width',
+    initialValue: GtSignaturePad.defaultStrokeWidth,
+    min: 1,
+    max: 8,
+  );
+  final isEnabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
+
+  return GtWidgetDocPage(
+    title: 'GtSignaturePad',
+    description: '''
+<b>GtSignaturePad</b> captures freehand signature strokes and supports native image selection via <b>AppImagePlugin</b>.
+The controller manages drawing, undo/redo history, and imported images, exposing the result as bytes or base64.''',
+    accessibilityNotes: const [
+      'Drawing is a pointer-only interaction and is not usable with a screen reader or for every motor ability.',
+      'The secondary upload action opens the native device image picker, or an accessible alternative if overridden.',
+      'Keep the upload action label specific to the accepted signature format and workflow.',
+    ],
+    code: '''
+final signatureController = GtSignaturePadController();
+
+GtSignaturePad(
+  controller: signatureController,
+  title: l10n.signaturePadTitle,
+  subtitle: l10n.signaturePadSubtitle,
+  // Automatically opens native image picker when onSecondaryAction is omitted:
+  secondaryActionSemanticLabel: l10n.uploadSignatureLabel,
+  semanticsLabel: l10n.signatureCanvasLabel,
+  semanticsHint: l10n.signatureCanvasHint,
+  undoSemanticLabel: l10n.undoSignatureLabel,
+  redoSemanticLabel: l10n.redoSignatureLabel,
+  clearSemanticLabel: l10n.clearSignatureLabel,
+  onChanged: (pngBytes) {},
+);
+
+// Programmatic image import via AppImagePlugin:
+await signatureController.pickImage();
+// Or direct bytes:
+signatureController.setImage(imageBytes);
+
+final bytes = signatureController.bytes;
+final base64 = signatureController.base64;
+final freshBytes = await signatureController.toUint8List();
+final freshBase64 = await signatureController.toBase64();''',
+    child: _SignaturePadPreview(
+      title: title,
+      subtitle: subtitle,
+      height: height,
+      strokeWidth: strokeWidth,
+      isEnabled: isEnabled,
+    ),
+  );
+}
+
+class _SignaturePadPreview extends GtStatefulWidget {
+  final String title;
+  final String subtitle;
+  final double height;
+  final double strokeWidth;
+  final bool isEnabled;
+
+  const _SignaturePadPreview({
+    required this.title,
+    required this.subtitle,
+    required this.height,
+    required this.strokeWidth,
+    required this.isEnabled,
+  });
+
+  @override
+  State<_SignaturePadPreview> createState() => _SignaturePadPreviewState();
+}
+
+class _SignaturePadPreviewState extends State<_SignaturePadPreview> {
+  final GtSignaturePadController _controller = GtSignaturePadController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        GtSignaturePad(
+          controller: _controller,
+          title: widget.title,
+          subtitle: widget.subtitle,
+          height: widget.height,
+          strokeWidth: widget.strokeWidth,
+          isEnabled: widget.isEnabled,
+          secondaryActionSemanticLabel: 'Upload a signature instead',
+          semanticsLabel: 'Signature drawing area',
+          semanticsHint:
+              'Draw with a finger or stylus, or use the upload signature action.',
+          undoSemanticLabel: 'Undo signature stroke',
+          redoSemanticLabel: 'Redo signature stroke',
+          clearSemanticLabel: 'Clear signature',
+        ),
+        const GtGap.yBase(),
+        GenericListener<GtSignaturePadValue>(
+          valueListenable: _controller,
+          builder: (state) {
+            final status = switch ((
+              state.isImage,
+              state.hasSignature,
+              state.isCapturing,
+            )) {
+              (_, _, true) => 'Encoding PNG…',
+              (true, _, _) => 'Signature imported from image · ready',
+              (false, true, false) => 'Signature drawn · undo available',
+              (false, false, false) when state.canRedo =>
+                'Signature undone · redo available',
+              _ => 'Waiting for a signature (draw or tap upload)',
+            };
+            return GtText(
+              status,
+              style: context.textStyles.bodyXs(
+                color: context.palette.text.darkerSub,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/gallery/lib/molecules/inputs/inputs.dart
+++ b/gallery/lib/molecules/inputs/inputs.dart
@@ -11,6 +11,7 @@ export 'gt_password_field_usecase.dart';
 export 'gt_phone_field_usecase.dart';
 export 'gt_pin_input_usecase.dart';
 export 'gt_search_field_usecase.dart';
+export 'gt_signature_pad_usecase.dart';
 export 'gt_text_field_usecase.dart';
 export 'gt_transfer_field_usecase.dart';
 export 'gt_url_field_usecase.dart';

--- a/gallery/lib/molecules/tiles/gt_list_tiles_usecase.dart
+++ b/gallery/lib/molecules/tiles/gt_list_tiles_usecase.dart
@@ -105,22 +105,98 @@ Widget playgroundGtSimpleActionListTileUseCase(BuildContext context) {
     label: 'Title',
     initialValue: 'Personal Info',
   );
+  final (trailingLabel, trailingIcon) =
+      context.knobs.object.dropdown<(String, IconData)>(
+    label: 'Trailing Icon',
+    initialOption: ('chevronRight', GtIcons.chevronRight),
+    options: const [
+      ('chevronRight', GtIcons.chevronRight),
+      ('chevronLeft', GtIcons.chevronLeft),
+      ('chevronDown', GtIcons.chevronDown),
+      ('chevronUp', GtIcons.chevronUp),
+      ('arrowNorthEast', GtIcons.arrowNorthEast),
+      ('arrowDoorOut', GtIcons.arrowDoorOut),
+      ('more', GtIcons.more),
+      ('moreHorizontal', GtIcons.moreHorizontal),
+      ('add', GtIcons.add),
+      ('cancel', GtIcons.cancel),
+      ('spark', GtIcons.spark),
+      ('info', GtIcons.info),
+    ],
+    labelBuilder: (option) => option.$1,
+  );
+  final trailingVariant = context.knobs.object.dropdown<GtIconVariant>(
+    label: 'Trailing Icon Variant',
+    initialOption: GtIconVariant.soft,
+    options: GtIconVariant.values,
+    labelBuilder: (v) => v.name,
+  );
+  final trailingIconSize = context.knobs.double.slider(
+    label: 'Trailing Icon Size',
+    initialValue: 20.0,
+    min: 14.0,
+    max: 36.0,
+  );
+  final (styleName, titleStyle) =
+      context.knobs.object.dropdown<(String, TextStyle?)>(
+    label: 'Title Style',
+    initialOption: ('Default (h6)', null),
+    options: [
+      ('Default (h6)', null),
+      ('h5', context.textStyles.h5()),
+      ('subHeadS', context.textStyles.subHeadS()),
+      ('bodyM', context.textStyles.bodyM()),
+      ('labelM', context.textStyles.labelM()),
+    ],
+    labelBuilder: (v) => v.$1,
+  );
+  final customPadding = context.knobs.boolean(
+    label: 'Custom Padding (Dense)',
+    initialValue: false,
+  );
+
+  final paddingParam = customPadding
+      ? '\n  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),'
+      : '';
+  final iconParam = trailingIcon == GtIcons.chevronRight
+      ? ''
+      : '\n  trailing: GtIcons.$trailingLabel,';
+  final sizeParam = trailingIconSize == 20.0
+      ? ''
+      : '\n  trailingIconSize: $trailingIconSize,';
+  final variantParam = trailingVariant == GtIconVariant.soft
+      ? ''
+      : '\n  trailingIconVariant: GtIconVariant.${trailingVariant.name},';
+  final styleParam = titleStyle == null
+      ? ''
+      : '\n  titleStyle: context.textStyles.$styleName(),';
+
+  final code = '''
+GtSimpleActionListTile(
+  "$title",$iconParam$sizeParam$variantParam$styleParam$paddingParam
+  onTap: () {},
+)''';
 
   return GtWidgetDocPage(
     title: "GtSimpleActionListTile",
     description:
         "A straightforward list tile used for simple navigation actions, featuring a title and a trailing chevron.",
-    code:
-        '''
-GtSimpleActionListTile(
-  "$title",
-  onTap: () {},
-)''',
+    code: code,
     child: Center(
       child: GtCard(
         padding: context.insets.symmetricDp(horizontal: 16.px, vertical: 8.px),
         variant: GtCardVariant.normal,
-        child: GtSimpleActionListTile(title, onTap: () {}),
+        child: GtSimpleActionListTile(
+          title,
+          trailing: trailingIcon,
+          trailingIconSize: trailingIconSize,
+          trailingIconVariant: trailingVariant,
+          titleStyle: titleStyle,
+          padding: customPadding
+              ? context.insets.symmetricDp(horizontal: 16.px, vertical: 6.px)
+              : null,
+          onTap: () {},
+        ),
       ),
     ),
   );

--- a/gallery/lib/molecules/tiles/gt_list_tiles_usecase.dart
+++ b/gallery/lib/molecules/tiles/gt_list_tiles_usecase.dart
@@ -105,10 +105,6 @@ Widget playgroundGtSimpleActionListTileUseCase(BuildContext context) {
     label: 'Title',
     initialValue: 'Personal Info',
   );
-  final subtitle = context.knobs.string(
-    label: 'Subtitle',
-    initialValue: 'View profile details',
-  );
 
   return GtWidgetDocPage(
     title: "GtSimpleActionListTile",
@@ -118,14 +114,13 @@ Widget playgroundGtSimpleActionListTileUseCase(BuildContext context) {
         '''
 GtSimpleActionListTile(
   "$title",
-  subtitle: "$subtitle",
   onTap: () {},
 )''',
     child: Center(
       child: GtCard(
         padding: context.insets.symmetricDp(horizontal: 16.px, vertical: 8.px),
         variant: GtCardVariant.normal,
-        child: GtSimpleActionListTile(title, subtitle: subtitle, onTap: () {}),
+        child: GtSimpleActionListTile(title, onTap: () {}),
       ),
     ),
   );

--- a/gallery/lib/molecules/tiles/gt_status_tiles_usecase.dart
+++ b/gallery/lib/molecules/tiles/gt_status_tiles_usecase.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gallery/lib.dart';
+import 'package:gt_mobile_foundation/data/models/media_data.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
@@ -66,7 +67,7 @@ Widget playgroundGtIllustratedStepTileUseCase(BuildContext context) {
 GtIllustratedStepTile(
   title: '$title',
   subtitle: '$subtitle',
-  illustrationPath: GtVectorIllustrations.security,
+  illustration: AppImageData(GtVectorIllustrations.security),
   isDone: $isDone,
 )''',
     child: Center(
@@ -76,7 +77,7 @@ GtIllustratedStepTile(
         child: GtIllustratedStepTile(
           title: title,
           subtitle: subtitle,
-          illustrationPath: GtVectorIllustrations.security,
+          illustration: AppImageData(GtVectorIllustrations.security),
           isDone: isDone,
         ),
       ),

--- a/gallery/lib/organisms/app_bars/gt_app_bar_gallery.dart
+++ b/gallery/lib/organisms/app_bars/gt_app_bar_gallery.dart
@@ -209,6 +209,33 @@ Widget buildGtModalAppbarUsecase(BuildContext context) {
     );
   }
 
+  showTitleModal({required String title}) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return Material(
+          type: .transparency,
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: 50.topBorderRadius,
+              color: context.palette.bg.white,
+            ),
+            child: Column(
+              mainAxisAlignment: .start,
+              crossAxisAlignment: .stretch,
+              children: [
+                GtModalAppBar.title(
+                  title: title,
+                  action: GtCancelButton(),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   final title = context.knobs.string(label: "Title", initialValue: "Schedule");
 
   return Scaffold(
@@ -233,6 +260,11 @@ Widget buildGtModalAppbarUsecase(BuildContext context) {
             onPressed: () => showModal(title: title, titleLeading: leading),
             text: "Show Prefixed Titled Modal AppBar",
             variant: .black,
+          ),
+          GtRaisedButton(
+            onPressed: () => showTitleModal(title: title),
+            text: "Show Title Header Modal AppBar",
+            variant: .primary,
           ),
         ],
       ),

--- a/gallery/lib/organisms/app_bars/gt_modal_app_bar_usecase.dart
+++ b/gallery/lib/organisms/app_bars/gt_modal_app_bar_usecase.dart
@@ -12,13 +12,28 @@ Widget playgroundGtModalAppBarUseCase(BuildContext context) {
   );
   final mode = context.knobs.object.dropdown<String>(
     label: 'Constructor Mode',
-    options: ['standard', 'withLeadingTitleimage', 'extended'],
+    options: ['standard', 'withLeadingTitleimage', 'extended', 'title'],
     initialOption: 'standard',
   );
 
   PreferredSizeWidget appBar;
   String modeCode;
-  if (mode == 'extended') {
+  if (mode == 'title') {
+    final showAction = context.knobs.boolean(
+      label: 'Show Action',
+      initialValue: true,
+    );
+    final action = showAction ? GtCancelButton() : null;
+    appBar = GtModalAppBar.title(
+      title: title,
+      action: action,
+    );
+    modeCode =
+        '''GtModalAppBar.title(
+  title: "$title",
+  action: ${showAction ? 'GtCancelButton()' : 'null'},
+)''';
+  } else if (mode == 'extended') {
     appBar = GtModalAppBar.extended(
       title: title,
       action: GtIconButton(icon: GtIcons.spark, onPressed: () {}),
@@ -57,7 +72,7 @@ Widget playgroundGtModalAppBarUseCase(BuildContext context) {
   return GtWidgetDocPage(
     title: 'GtModalAppBar',
     description:
-        'An app bar tailored for modal bottom sheets and overlays, featuring a centered title and close/action controls.',
+        'An app bar tailored for modal bottom sheets and overlays, featuring title headers and close/action controls.',
     code: modeCode,
     child: appBar,
   );

--- a/gallery/lib/organisms/cards/gt_state_cards_usecase.dart
+++ b/gallery/lib/organisms/cards/gt_state_cards_usecase.dart
@@ -4,8 +4,29 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
+const _illustrationOptions = [
+  (name: 'emptyState', path: GtVectorIllustrations.emptyState),
+  (name: 'empty', path: GtVectorIllustrations.empty),
+  (name: 'notFound', path: GtVectorIllustrations.notFound),
+  (name: 'search', path: GtVectorIllustrations.search),
+  (name: 'details', path: GtVectorIllustrations.details),
+];
+
+const _iconOptions = [
+  (name: 'userSearch', icon: GtIcons.userSearch),
+  (name: 'search', icon: GtIcons.search),
+  (name: 'fileContent', icon: GtIcons.fileContent),
+  (name: 'bankCard', icon: GtIcons.bankCard),
+  (name: 'notificationSolid', icon: GtIcons.notificationSolid),
+];
+
 @widgetbook.UseCase(name: 'GtEmptyStateCard', type: GtEmptyStateCard)
 Widget playgroundGtEmptyStateCardUseCase(BuildContext context) {
+  final mode = context.knobs.object.dropdown<String>(
+    label: 'Card Mode',
+    options: ['icon', 'image'],
+    initialOption: 'icon',
+  );
   final description = context.knobs.string(
     label: 'Description',
     initialValue: 'You currently do not have any team member here',
@@ -16,23 +37,111 @@ Widget playgroundGtEmptyStateCardUseCase(BuildContext context) {
     initialOption: GtCardVariant.normal,
     labelBuilder: (v) => v.name,
   );
+  final spacing = context.knobs.double.slider(
+    label: 'Spacing',
+    initialValue: 8.0,
+    min: 0.0,
+    max: 32.0,
+  );
+  final hasFooter = context.knobs.boolean(
+    label: 'Show Footer',
+    initialValue: false,
+  );
+  final footerText = context.knobs.string(
+    label: 'Footer Button Text',
+    initialValue: 'Add Team Member',
+  );
+
+  final selectedIconItem = context.knobs.objectOrNull
+      .dropdown<({String name, IconData icon})?>(
+        label: 'Icon',
+        options: [..._iconOptions, null],
+        initialOption: _iconOptions.first,
+        labelBuilder: (option) => option == null ? 'None (null)' : option.name,
+      );
+
+  final iconSize = context.knobs.double.slider(
+    label: 'Icon Size',
+    initialValue: 24.0,
+    min: 16.0,
+    max: 64.0,
+  );
+
+  final selectedIllustration = context.knobs.object
+      .dropdown<({String name, String path})>(
+        label: 'Illustration',
+        options: _illustrationOptions,
+        initialOption: _illustrationOptions.first,
+        labelBuilder: (option) => option.name,
+      );
+
+  final imageSize = context.knobs.double.slider(
+    label: 'Image Size',
+    initialValue: 80.0,
+    min: 40.0,
+    max: 160.0,
+  );
+
+  final footerWidget = hasFooter
+      ? GtRaisedButton(text: footerText, size: .xsmall, onPressed: () {})
+      : null;
+
+  Widget cardWidget;
+  String codeSnippet;
+
+  if (mode == 'image') {
+    cardWidget = GtEmptyStateCard.image(
+      image: GtSvg(
+        selectedIllustration.path,
+        width: imageSize.px,
+        height: imageSize.px,
+      ),
+      description: description,
+      variant: variant,
+      spacing: spacing,
+      footer: footerWidget,
+    );
+    codeSnippet =
+        '''
+GtEmptyStateCard.image(
+  image: GtSvg(
+    GtVectorIllustrations.${selectedIllustration.name},
+    width: ${imageSize.toInt()},
+    height: ${imageSize.toInt()},
+  ),
+  description: "$description",
+  variant: GtCardVariant.${variant.name},
+  spacing: ${spacing.toInt()},${hasFooter ? '\n  footer: GtRaisedButton(\n    text: "$footerText",\n    size: .xsmall,\n    onPressed: () {},\n  ),' : ''}
+)''';
+  } else {
+    cardWidget = GtEmptyStateCard(
+      icon: selectedIconItem?.icon,
+      iconSize: iconSize,
+      description: description,
+      variant: variant,
+      spacing: spacing,
+      footer: footerWidget,
+    );
+    final iconSnippet = selectedIconItem == null
+        ? 'null'
+        : 'GtIcons.${selectedIconItem.name}';
+    codeSnippet =
+        '''
+GtEmptyStateCard(
+  icon: $iconSnippet,
+  iconSize: ${iconSize.toInt()},
+  description: "$description",
+  variant: GtCardVariant.${variant.name},
+  spacing: ${spacing.toInt()},${hasFooter ? '\n  footer: GtRaisedButton(\n    text: "$footerText",\n    size: .xsmall,\n    onPressed: () {},\n  ),' : ''}
+)''';
+  }
 
   return GtWidgetDocPage(
     title: 'GtEmptyStateCard',
     description:
-        'A static card displaying empty state placeholder messages and status icons.',
-    code:
-        '''
-GtEmptyStateCard(
-  icon: GtIcons.userSearch,
-  description: "$description",
-  variant: GtCardVariant.${variant.name},
-)''',
-    child: GtEmptyStateCard(
-      icon: GtIcons.userSearch,
-      description: description,
-      variant: variant,
-    ),
+        'A static card displaying empty state placeholder messages and status icons or illustrations.',
+    code: codeSnippet,
+    child: cardWidget,
   );
 }
 

--- a/gallery/lib/templates/forms/gt_virtual_keypad_form_doc.dart
+++ b/gallery/lib/templates/forms/gt_virtual_keypad_form_doc.dart
@@ -12,6 +12,16 @@ GtVirtualKeypadForm(
   title: 'Enter PIN',
   subtitle: 'Please enter your secure 4-digit transaction PIN.',
   maxLength: 4,
+  fillInactiveDots: false,
+  onBioAuth: () {
+    // Biometric Auth callback
+  },
+  action: GtHelpButton(onPressed: () {}),
+  footer: GtQuestionTextButton(
+    "Forgot PIN?",
+    action: "Reset now",
+    onPressed: () {},
+  ),
 )''';
 
   return GtWidgetDocPage(

--- a/gallery/lib/templates/forms/gt_virtual_keypad_form_usecase.dart
+++ b/gallery/lib/templates/forms/gt_virtual_keypad_form_usecase.dart
@@ -16,6 +16,30 @@ Widget playgroundGtVirtualKeypadFormUseCase(BuildContext context) {
     min: 4,
     max: 6,
   );
+  final fillInactiveDots = context.knobs.boolean(
+    label: 'Fill Inactive Dots',
+    initialValue: false,
+  );
+  final hasHelperText = context.knobs.boolean(
+    label: 'Show Helper Text',
+    initialValue: false,
+  );
+  final hasErrorText = context.knobs.boolean(
+    label: 'Show Error Text',
+    initialValue: false,
+  );
+  final enableBioAuth = context.knobs.boolean(
+    label: 'Enable Biometric Auth',
+    initialValue: true,
+  );
+  final showAction = context.knobs.boolean(
+    label: 'Show App Bar Action (Help)',
+    initialValue: true,
+  );
+  final showFooter = context.knobs.boolean(
+    label: 'Show Footer',
+    initialValue: false,
+  );
 
   return Scaffold(
     body: GtVirtualKeypadForm(
@@ -24,6 +48,19 @@ Widget playgroundGtVirtualKeypadFormUseCase(BuildContext context) {
       title: title,
       subtitle: subtitle,
       maxLength: maxLength,
+      fillInactiveDots: fillInactiveDots,
+      helperText:
+          hasHelperText ? 'Please do not share your PIN with anyone.' : null,
+      errorText: hasErrorText ? 'Incorrect PIN. 2 attempts remaining.' : null,
+      onBioAuth: enableBioAuth ? () {} : null,
+      action: showAction ? GtHelpButton(onPressed: () {}) : null,
+      footer: showFooter
+          ? GtQuestionTextButton(
+              "Forgot PIN?",
+              action: "Reset now",
+              onPressed: () {},
+            )
+          : null,
     ),
   );
 }

--- a/gallery/lib/templates/forms/gt_virtual_keypad_form_with_avatar_doc.dart
+++ b/gallery/lib/templates/forms/gt_virtual_keypad_form_with_avatar_doc.dart
@@ -15,10 +15,17 @@ Scaffold(
     controller: pinController,
     name: 'Alex Lobaloba',
     avatar: AppImageData.asset(GtAssetImages.avatar),
+    headerQuestionButton: GtQuestionTextButton(
+      "Not you?",
+      action: "Switch account",
+      onPressed: () {},
+    ),
     maxLength: 4,
+    fillInactiveDots: false,
     onBioAuth: () {
       // Biometric Auth callback
     },
+    action: GtHelpButton(onPressed: () {}),
   ),
 )''';
 

--- a/gallery/lib/templates/forms/gt_virtual_keypad_form_with_avatar_usecase.dart
+++ b/gallery/lib/templates/forms/gt_virtual_keypad_form_with_avatar_usecase.dart
@@ -18,6 +18,42 @@ Widget playgroundGtVirtualKeypadFormWithAvatarUseCase(BuildContext context) {
     min: 4,
     max: 6,
   );
+  final fillInactiveDots = context.knobs.boolean(
+    label: 'Fill Inactive Dots',
+    initialValue: false,
+  );
+  final showHeaderQuestion = context.knobs.boolean(
+    label: 'Show Header Question Button',
+    initialValue: true,
+  );
+  final questionText = context.knobs.string(
+    label: 'Header Question Text',
+    initialValue: 'Not you?',
+  );
+  final actionText = context.knobs.string(
+    label: 'Header Action Text',
+    initialValue: 'Switch account',
+  );
+  final hasHelperText = context.knobs.boolean(
+    label: 'Show Helper Text',
+    initialValue: false,
+  );
+  final hasErrorText = context.knobs.boolean(
+    label: 'Show Error Text',
+    initialValue: false,
+  );
+  final enableBioAuth = context.knobs.boolean(
+    label: 'Enable Biometric Auth',
+    initialValue: true,
+  );
+  final showAction = context.knobs.boolean(
+    label: 'Show App Bar Action (Help)',
+    initialValue: true,
+  );
+  final showFooter = context.knobs.boolean(
+    label: 'Show Footer',
+    initialValue: false,
+  );
 
   return Scaffold(
     body: GtVirtualKeypadForm.withAvatar(
@@ -25,7 +61,25 @@ Widget playgroundGtVirtualKeypadFormWithAvatarUseCase(BuildContext context) {
       controller: TextEditingController(),
       name: name,
       maxLength: maxLength,
-      onBioAuth: () {},
+      fillInactiveDots: fillInactiveDots,
+      headerQuestionButton: showHeaderQuestion
+          ? GtQuestionTextButton(
+              questionText,
+              action: actionText,
+              onPressed: () {},
+            )
+          : null,
+      helperText: hasHelperText ? 'Enter your 4-digit passcode' : null,
+      errorText: hasErrorText ? 'Incorrect PIN entered' : null,
+      onBioAuth: enableBioAuth ? () {} : null,
+      action: showAction ? GtHelpButton(onPressed: () {}) : null,
+      footer: showFooter
+          ? GtQuestionTextButton(
+              "Having trouble?",
+              action: "Get help",
+              onPressed: () {},
+            )
+          : null,
     ),
   );
 }

--- a/lib/common/data/data.dart
+++ b/lib/common/data/data.dart
@@ -8,6 +8,7 @@ export 'gt_input_data.dart';
 export 'gt_keycell_data.dart';
 export 'gt_receipt_data.dart';
 export 'gt_slide_data.dart';
+export 'gt_signature_pad_data.dart';
 export 'gt_status_step_data.dart';
 export 'gt_success_rate_data.dart';
 export 'gt_summary_data.dart';

--- a/lib/common/data/gt_signature_pad_data.dart
+++ b/lib/common/data/gt_signature_pad_data.dart
@@ -1,0 +1,298 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+
+/// A single continuous stroke drawn on a [GtSignaturePadController].
+@immutable
+class GtSignatureStroke {
+  /// The ordered canvas-local points that make up this stroke.
+  final List<Offset> points;
+
+  /// Creates an immutable signature stroke from [points].
+  GtSignatureStroke(Iterable<Offset> points)
+    : points = List<Offset>.unmodifiable(points);
+
+  /// Returns a new stroke with [point] appended.
+  GtSignatureStroke add(Offset point) {
+    return GtSignatureStroke([...points, point]);
+  }
+}
+
+/// Immutable drawing and history state managed by [GtSignaturePadController].
+@immutable
+class GtSignaturePadValue {
+  /// Completed strokes currently visible on the canvas.
+  final List<GtSignatureStroke> strokes;
+
+  /// Strokes available to restore through redo.
+  final List<GtSignatureStroke> redoStrokes;
+
+  /// Whether a pointer is currently adding points to the latest stroke.
+  final bool isDrawing;
+
+  /// Whether the current drawing is being encoded as a PNG.
+  final bool isCapturing;
+
+  /// The raw bytes of an imported or uploaded signature image.
+  final Uint8List? image;
+
+  /// Creates signature pad state.
+  GtSignaturePadValue({
+    Iterable<GtSignatureStroke> strokes = const [],
+    Iterable<GtSignatureStroke> redoStrokes = const [],
+    this.isDrawing = false,
+    this.isCapturing = false,
+    this.image,
+  }) : strokes = List<GtSignatureStroke>.unmodifiable(strokes),
+       redoStrokes = List<GtSignatureStroke>.unmodifiable(redoStrokes);
+
+  /// Whether no signature marks or images are currently visible.
+  bool get isEmpty => strokes.isEmpty && image == null;
+
+  /// Whether at least one signature mark or uploaded image is currently visible.
+  bool get hasSignature => !isEmpty;
+
+  /// Whether the signature is backed by an imported image.
+  bool get isImage => image != null;
+
+  /// Whether the latest visible stroke can be removed.
+  bool get canUndo => strokes.isNotEmpty;
+
+  /// Whether the latest undone stroke can be restored.
+  bool get canRedo => redoStrokes.isNotEmpty;
+}
+
+/// Controls the drawing, history, and PNG output of a signature pad.
+///
+/// The controller is the source of truth for the scribble and imported signature images.
+/// It also owns the foundation [ScreenShotService] used to rasterize the keyed drawing boundary.
+/// [bytes] and [base64] synchronously expose the latest completed capture or imported image;
+/// [toUint8List] and [toBase64] request a fresh asynchronous capture.
+class GtSignaturePadController extends ValueNotifier<GtSignaturePadValue> {
+  static const double _minimumPointDistanceSquared = .25;
+
+  final ScreenShotService _screenShotService;
+  final ValueNotifier<Uint8List?> _imageNotifier = ValueNotifier(null);
+
+  int _captureGeneration = 0;
+  bool _isDisposed = false;
+
+  /// Creates an empty signature controller.
+  GtSignaturePadController({ScreenShotService? screenShotService})
+    : _screenShotService = screenShotService ?? ScreenShotService(),
+      super(GtSignaturePadValue());
+
+  /// The boundary key used by [ScreenShotService] to capture only the drawing.
+  ///
+  /// Consumers normally do not need this; [GtSignaturePad] binds it for them.
+  GlobalKey get repaintBoundaryKey => _screenShotService.screenShotKey;
+
+  /// Emits whenever a newly encoded PNG becomes available or the pad clears.
+  ValueListenable<Uint8List?> get imageListenable => _imageNotifier;
+
+  /// The latest PNG-encoded or imported signature, or `null` before capture or after clear.
+  ///
+  /// A defensive copy is returned so caller mutation cannot corrupt the cache.
+  Uint8List? get bytes {
+    if (value.image != null) return _copyBytes(value.image);
+    return _copyBytes(_imageNotifier.value);
+  }
+
+  /// The latest PNG-encoded or imported signature as base64, or `null` when unavailable.
+  String? get base64 {
+    final data = bytes;
+    return data == null ? null : base64Encode(data);
+  }
+
+  /// Whether the pad currently contains at least one visible stroke or imported image.
+  bool get hasSignature => value.hasSignature;
+
+  /// Whether the current signature is backed by an imported image.
+  bool get isImage => value.isImage;
+
+  /// Whether a visible stroke can be removed.
+  bool get canUndo => value.canUndo;
+
+  /// Whether an undone stroke can be restored.
+  bool get canRedo => value.canRedo;
+
+  /// Sets an imported signature image and clears existing strokes.
+  void setImage(Uint8List? image) {
+    _invalidateCapture();
+    value = GtSignaturePadValue(image: image);
+    _setImage(image);
+  }
+
+  /// Opens the device's native image selector and sets the selected image as signature.
+  ///
+  /// Returns `true` if an image was picked and loaded successfully.
+  Future<bool> pickImage({int? imageQuality}) async {
+    final response = await AppImagePlugin.pickImage(imageQuality: imageQuality);
+    if (response.hasFile && response.file != null) {
+      final bytes = await response.file!.readAsBytes();
+      setImage(bytes);
+      return true;
+    }
+    return false;
+  }
+
+  /// Starts a new continuous stroke at [point].
+  void beginStroke(Offset point) {
+    _invalidateCapture();
+    value = GtSignaturePadValue(
+      strokes: [
+        ...value.strokes,
+        GtSignatureStroke([point]),
+      ],
+      isDrawing: true,
+      image: null,
+    );
+  }
+
+  /// Adds [point] to the active stroke.
+  ///
+  /// Points that are too close to the previous point are ignored to keep the
+  /// path compact without changing its visible shape.
+  void appendPoint(Offset point) {
+    if (!value.isDrawing || value.strokes.isEmpty) return;
+
+    final activeStroke = value.strokes.last;
+    final previousPoint = activeStroke.points.last;
+    if ((point - previousPoint).distanceSquared <
+        _minimumPointDistanceSquared) {
+      return;
+    }
+
+    value = GtSignaturePadValue(
+      strokes: [
+        ...value.strokes.take(value.strokes.length - 1),
+        activeStroke.add(point),
+      ],
+      isDrawing: true,
+      image: null,
+    );
+  }
+
+  /// Completes the active stroke and schedules its PNG capture.
+  void endStroke() {
+    if (!value.isDrawing) return;
+    value = GtSignaturePadValue(strokes: value.strokes);
+    _scheduleCapture();
+  }
+
+  /// Removes the most recently drawn stroke.
+  void undo() {
+    if (!canUndo) return;
+
+    _invalidateCapture();
+    final removedStroke = value.strokes.last;
+    value = GtSignaturePadValue(
+      strokes: value.strokes.take(value.strokes.length - 1),
+      redoStrokes: [...value.redoStrokes, removedStroke],
+    );
+    _scheduleCapture();
+  }
+
+  /// Restores the most recently undone stroke.
+  void redo() {
+    if (!canRedo) return;
+
+    _invalidateCapture();
+    final restoredStroke = value.redoStrokes.last;
+    value = GtSignaturePadValue(
+      strokes: [...value.strokes, restoredStroke],
+      redoStrokes: value.redoStrokes.take(value.redoStrokes.length - 1),
+    );
+    _scheduleCapture();
+  }
+
+  /// Removes the drawing and all undo/redo history.
+  void clear() {
+    _invalidateCapture();
+    value = GtSignaturePadValue();
+    _setImage(null);
+  }
+
+  /// Captures the current signature as PNG bytes.
+  ///
+  /// If an imported image is active, its bytes are returned directly.
+  /// The drawing surface must be mounted in a [GtSignaturePad]. If it is not,
+  /// the latest cached bytes are returned instead. [pixelRatio] defaults to the
+  /// mounted surface's device pixel ratio through [ScreenShotService].
+  Future<Uint8List?> toUint8List({double? pixelRatio}) async {
+    if (value.image != null) return bytes;
+    if (!hasSignature) {
+      _setImage(null);
+      return null;
+    }
+
+    final captureContext = repaintBoundaryKey.currentContext;
+    if (captureContext == null) return bytes;
+
+    final generation = ++_captureGeneration;
+    _setCapturing(true);
+    final image = await _screenShotService.captureScreen(
+      captureContext,
+      pixelRatio: pixelRatio,
+    );
+
+    if (_isDisposed || generation != _captureGeneration) return bytes;
+    _setImage(image);
+    _setCapturing(false);
+    return bytes;
+  }
+
+  /// Captures the current signature and returns its PNG bytes as base64.
+  Future<String?> toBase64({double? pixelRatio}) async {
+    final image = await toUint8List(pixelRatio: pixelRatio);
+    return image == null ? null : base64Encode(image);
+  }
+
+  void _scheduleCapture() {
+    if (!hasSignature) {
+      _setImage(null);
+      return;
+    }
+
+    final scheduledGeneration = ++_captureGeneration;
+    _setCapturing(true);
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (_isDisposed || scheduledGeneration != _captureGeneration) return;
+      await toUint8List();
+    });
+  }
+
+  void _invalidateCapture() {
+    _captureGeneration++;
+  }
+
+  void _setCapturing(bool isCapturing) {
+    if (_isDisposed || value.isCapturing == isCapturing) return;
+    value = GtSignaturePadValue(
+      strokes: value.strokes,
+      redoStrokes: value.redoStrokes,
+      isDrawing: value.isDrawing,
+      isCapturing: isCapturing,
+      image: value.image,
+    );
+  }
+
+  void _setImage(Uint8List? image) {
+    if (_isDisposed) return;
+    _imageNotifier.value = _copyBytes(image);
+  }
+
+  static Uint8List? _copyBytes(Uint8List? image) {
+    return image == null ? null : Uint8List.fromList(image);
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    _captureGeneration++;
+    _imageNotifier.dispose();
+    super.dispose();
+  }
+}

--- a/lib/common/painters/gt_signature_painter.dart
+++ b/lib/common/painters/gt_signature_painter.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// Paints the strokes held by a [GtSignaturePadController].
+class GtSignaturePainter extends CustomPainter {
+  /// Controller that owns the signature strokes and repaint notifications.
+  final GtSignaturePadController controller;
+
+  /// Color used to paint the signature.
+  final Color strokeColor;
+
+  /// Width of the signature stroke in logical pixels.
+  final double strokeWidth;
+
+  /// Creates a signature painter.
+  GtSignaturePainter({
+    required this.controller,
+    required this.strokeColor,
+    required this.strokeWidth,
+  }) : super(repaint: controller);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = strokeColor
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..style = PaintingStyle.stroke
+      ..isAntiAlias = true;
+
+    for (final stroke in controller.value.strokes) {
+      final points = stroke.points;
+      if (points.isEmpty) continue;
+
+      if (points.length == 1) {
+        canvas.drawCircle(
+          points.single,
+          strokeWidth / 2,
+          paint..style = PaintingStyle.fill,
+        );
+        paint.style = PaintingStyle.stroke;
+        continue;
+      }
+
+      final path = Path()..moveTo(points.first.dx, points.first.dy);
+      for (var index = 1; index < points.length; index++) {
+        final previous = points[index - 1];
+        final current = points[index];
+        final midpoint = Offset(
+          (previous.dx + current.dx) / 2,
+          (previous.dy + current.dy) / 2,
+        );
+        path.quadraticBezierTo(
+          previous.dx,
+          previous.dy,
+          midpoint.dx,
+          midpoint.dy,
+        );
+      }
+      path.lineTo(points.last.dx, points.last.dy);
+      canvas.drawPath(path, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant GtSignaturePainter oldDelegate) {
+    return oldDelegate.controller != controller ||
+        oldDelegate.strokeColor != strokeColor ||
+        oldDelegate.strokeWidth != strokeWidth;
+  }
+}

--- a/lib/common/painters/painters.dart
+++ b/lib/common/painters/painters.dart
@@ -4,4 +4,5 @@ export 'gt_dashed_painter.dart';
 export 'gt_home_gradient_painter.dart';
 export 'gt_pie_painter.dart';
 export 'gt_progress_painter.dart';
+export 'gt_signature_painter.dart';
 export 'gt_trend_painter.dart';

--- a/lib/common/physics/gt_marquee_scroll_physics.dart
+++ b/lib/common/physics/gt_marquee_scroll_physics.dart
@@ -1,29 +1,56 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/physics.dart';
 
-/// A custom [ScrollPhysics] that creates an automatic, continuous scrolling
-/// effect (like a marquee) when attached to a scrollable widget.
+/// A custom [ScrollPhysics] that creates an automatic, continuous back-and-forth
+/// scrolling effect (ping-pong marquee) when attached to a scrollable widget.
 ///
-/// Once the scroll position reaches the [maxScrollExtent], it snaps back
-/// to the beginning using a spring simulation, creating an infinite loop effect.
+/// When the scrollable content exceeds the viewport, it automatically
+/// scrolls to the end, pauses briefly, scrolls back to the start, pauses, and
+/// repeats continuously.
 class GtMarqueeScrollPhysics extends ScrollPhysics {
-  /// The constant velocity at which the marquee scrolls.
+  /// The constant velocity in pixels per second at which the marquee scrolls.
   ///
-  /// A higher value results in faster scrolling. The absolute value of this
-  /// velocity is used for the continuous scroll simulation. Defaults to `10`.
+  /// Defaults to `20.0`.
   final double marqueeVelocity;
 
-  /// Creates a [GtMarqueeScrollPhysics] instance.
+  /// The duration to pause at each boundary (start and end) before reversing direction.
   ///
-  /// The [marqueeVelocity] dictates the speed of the scroll, and [parent]
-  /// is an optional parent [ScrollPhysics] to inherit behavior from.
-  const GtMarqueeScrollPhysics({this.marqueeVelocity = 10, super.parent});
+  /// Defaults to `1200ms` (1.2 seconds).
+  final Duration pauseDuration;
+
+  /// Creates a [GtMarqueeScrollPhysics] instance.
+  const GtMarqueeScrollPhysics({
+    this.marqueeVelocity = 20.0,
+    this.pauseDuration = const Duration(milliseconds: 1200),
+    super.parent,
+  });
 
   @override
   GtMarqueeScrollPhysics applyTo(ScrollPhysics? ancestor) {
     return GtMarqueeScrollPhysics(
       marqueeVelocity: marqueeVelocity,
+      pauseDuration: pauseDuration,
       parent: buildParent(ancestor),
+    );
+  }
+
+  @override
+  double adjustPositionForNewDimensions({
+    required ScrollMetrics oldPosition,
+    required ScrollMetrics newPosition,
+    required bool isScrolling,
+    required double velocity,
+  }) {
+    if (newPosition.maxScrollExtent > newPosition.minScrollExtent &&
+        !isScrolling &&
+        newPosition.pixels == newPosition.minScrollExtent) {
+      // Offset by a fractional pixel to kick off ballistic marquee activity on initial layout.
+      return newPosition.pixels + 0.001;
+    }
+    return super.adjustPositionForNewDimensions(
+      oldPosition: oldPosition,
+      newPosition: newPosition,
+      isScrolling: isScrolling,
+      velocity: velocity,
     );
   }
 
@@ -32,30 +59,104 @@ class GtMarqueeScrollPhysics extends ScrollPhysics {
     ScrollMetrics position,
     double velocity,
   ) {
-    // If the content is smaller than the viewport, fall back to default behavior.
+    // If the content is smaller than or equal to the viewport, no scrolling needed.
     if (position.maxScrollExtent <= position.minScrollExtent) {
       return super.createBallisticSimulation(position, velocity);
     }
 
-    // If we've reached or exceeded the end of the scrollable area,
-    // spring back to the beginning (0) to create a continuous loop.
-    if (position.pixels >= position.maxScrollExtent) {
-      const spring = SpringDescription(mass: 1, stiffness: 0.5, damping: 1);
+    final double speed = marqueeVelocity.abs();
+    if (speed == 0) return null;
 
-      return SpringSimulation(spring, position.pixels, 0, 1);
+    final double min = position.minScrollExtent;
+    final double max = position.maxScrollExtent;
+    final double current = position.pixels;
+
+    // Determine target based on current position and velocity.
+    double target;
+    Duration pause = pauseDuration;
+
+    if (current >= max - 0.5) {
+      // At or past the end: reverse and scroll back to the start.
+      target = min;
+    } else if (current <= min + 0.5) {
+      // At or before the start: scroll forward to the end.
+      target = max;
+    } else if (velocity > 0) {
+      // In the middle with positive velocity (e.g. after user drag or continuing forward):
+      target = max;
+      pause = Duration.zero;
+    } else if (velocity < 0) {
+      // In the middle with negative velocity:
+      target = min;
+      pause = Duration.zero;
+    } else {
+      // In the middle with 0 velocity: target the end
+      target = max;
+      pause = Duration.zero;
     }
 
-    // Otherwise, apply a constant gravity-like velocity towards the max scroll extent.
-    return GravitySimulation(
-      1,
-      position.pixels,
-      position.maxScrollExtent,
-      marqueeVelocity.abs(),
+    return _GtMarqueeSimulation(
+      start: current,
+      end: target,
+      velocity: speed,
+      pauseDuration: pause,
     );
   }
 
   @override
   String toString() {
-    return 'MarqueeScrollPhysics(marqueeVelocity: $marqueeVelocity, parent: $parent)';
+    return 'GtMarqueeScrollPhysics(marqueeVelocity: $marqueeVelocity, pauseDuration: $pauseDuration, parent: $parent)';
+  }
+}
+
+/// A linear simulation for marquee scrolling that can hold at the starting position
+/// for a specified [pauseDuration] before moving at a constant [velocity] to [end].
+class _GtMarqueeSimulation extends Simulation {
+  _GtMarqueeSimulation({
+    required this.start,
+    required this.end,
+    required this.velocity,
+    this.pauseDuration = Duration.zero,
+  }) : _distance = (end - start).abs(),
+       _direction = end >= start ? 1.0 : -1.0,
+       _pauseSeconds = pauseDuration.inMicroseconds / 1000000.0 {
+    _scrollSeconds = velocity > 0 ? _distance / velocity : 0.0;
+    _totalSeconds = _pauseSeconds + _scrollSeconds;
+  }
+
+  final double start;
+  final double end;
+  final double velocity;
+  final Duration pauseDuration;
+
+  final double _distance;
+  final double _direction;
+  final double _pauseSeconds;
+  late final double _scrollSeconds;
+  late final double _totalSeconds;
+
+  @override
+  double x(double time) {
+    if (time <= _pauseSeconds) {
+      return start;
+    }
+    if (time >= _totalSeconds || _scrollSeconds <= 0) {
+      return end;
+    }
+    final double progress = (time - _pauseSeconds) / _scrollSeconds;
+    return start + (end - start) * progress;
+  }
+
+  @override
+  double dx(double time) {
+    if (time <= _pauseSeconds || time >= _totalSeconds) {
+      return 0.0;
+    }
+    return _direction * velocity;
+  }
+
+  @override
+  bool isDone(double time) {
+    return time >= _totalSeconds;
   }
 }

--- a/lib/common/styling/gt_shadows.dart
+++ b/lib/common/styling/gt_shadows.dart
@@ -277,7 +277,9 @@ class GtShadows {
     ];
   }
 
-  /// Inner glass shadow used by bottom navigation containers and buttons.
+  /// Drop shadow cast by the floating bottom navigation glass surfaces.
+  ///
+  /// Matches the Figma `Fill + Shadow` layer: `0 8px 40px rgba(0,0,0,0.12)`.
   ///
   /// Accepts an optional [color] to override the default theme shadow color.
   List<BoxShadow> bottomNavShadow([Color? color]) {
@@ -286,7 +288,7 @@ class GtShadows {
         spreadRadius: 0,
         offset: Offset(0, 8),
         blurRadius: 40,
-        color: (color ?? context.palette.bg.strong).setOpacity(.24),
+        color: (color ?? context.palette.bg.strong).setOpacity(.12),
       ),
     ];
   }

--- a/lib/widgets/molecules/buttons/gt_back_button.dart
+++ b/lib/widgets/molecules/buttons/gt_back_button.dart
@@ -91,13 +91,15 @@ class GtBackButton extends GtStatelessWidget {
 
               Navigator.of(context).maybePop();
             },
-            child: GtSquareConstrainedBox(
-              cubeSize,
-              child: GtIcon.withColor(
-                GtIcons.chevronLeft,
-                size: iconSize,
-                alignment: .center,
-                color: color ?? context.palette.icon.strong,
+            child: GtTapTarget(
+              child: GtSquareConstrainedBox(
+                cubeSize,
+                child: GtIcon.withColor(
+                  GtIcons.chevronLeft,
+                  size: iconSize,
+                  alignment: .center,
+                  color: color ?? context.palette.icon.strong,
+                ),
               ),
             ),
           ),

--- a/lib/widgets/molecules/buttons/gt_semantic_buttons.dart
+++ b/lib/widgets/molecules/buttons/gt_semantic_buttons.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
@@ -118,5 +119,65 @@ class GtAccountSwitchButton extends GtStatelessWidget {
     }
 
     return child;
+  }
+}
+
+/// An interactive text button combining a question or prompt with a clickable action.
+///
+/// Commonly used for navigation and authentication prompts (e.g., "Don't have an account? Sign up"),
+/// rendering the prompt with a subtle text style and the action with prominent styling.
+class GtQuestionTextButton extends GtStatelessWidget {
+  /// Creates a [GtQuestionTextButton].
+  const GtQuestionTextButton(
+    this.question, {
+    super.key,
+    required this.action,
+    required this.onPressed,
+    this.questionStyle,
+    this.actionStyle,
+    this.textAlign,
+  });
+
+  /// The question or prompt text displayed before the action.
+  final String question;
+
+  /// The action text displayed after the question.
+  final String action;
+
+  /// Callback invoked when the button or action text is tapped.
+  final OnPressed onPressed;
+
+  /// An optional text style to override the default question style.
+  final TextStyle? questionStyle;
+
+  /// An optional text style to override the default action style.
+  final TextStyle? actionStyle;
+
+  /// An optional alignment for the button's content.
+  final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    final questionColor = context.palette.text.darkerSub;
+    final defaultStyle = context.textStyles.subHeadS();
+    final defaultQuesStyle = defaultStyle.copyWith(color: questionColor);
+
+    return GtInkWell(
+      role: .button,
+      onTap: onPressed,
+      child: GtTapTarget(
+        child: Text.rich(
+          TextSpan(
+            text: question,
+            children: [
+              TextSpan(text: " $action", style: actionStyle ?? defaultStyle),
+            ],
+            recognizer: TapGestureRecognizer()..onTap = onPressed,
+            style: questionStyle ?? defaultQuesStyle,
+          ),
+          textAlign: textAlign ?? .center,
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/molecules/inputs/gt_dot_form_field.dart
+++ b/lib/widgets/molecules/inputs/gt_dot_form_field.dart
@@ -105,7 +105,7 @@ class _GtDotFormFieldState extends State<GtDotFormField> {
                   if (helperText.hasValue)
                     GtText(
                       helperText,
-                      style: context.textStyles.bodyM(color: textColor),
+                      style: context.textStyles.bodyS(color: textColor),
                       textAlign: .center,
                       maxLines: 3,
                     ),

--- a/lib/widgets/molecules/inputs/gt_search_field.dart
+++ b/lib/widgets/molecules/inputs/gt_search_field.dart
@@ -53,6 +53,9 @@ class GtSearchField extends GtStatefulWidget {
   /// An optional Hero animation tag used to animate transitions between screens.
   final String? _heroTag;
 
+  /// An optional semantic label for the search field.
+  final String? _actionSemanticsLabel;
+
   /// Creates a standard editable [GtSearchField].
   const GtSearchField({
     super.key,
@@ -73,6 +76,7 @@ class GtSearchField extends GtStatefulWidget {
     String? heroTag,
   }) : _readonly = readonly,
        _onTap = onTap,
+       _actionSemanticsLabel = null,
        _heroTag = heroTag;
 
   /// Creates a read-only [GtSearchField] that acts as an interactive button to trigger an action (e.g. opening a search page or modal).
@@ -93,10 +97,12 @@ class GtSearchField extends GtStatefulWidget {
     this.suffix,
     this.clearSemanticLabel,
     required OnPressed onTap,
+    String? actionSemanticsLabel,
     String? heroTag,
   }) : _readonly = true,
        autoFocus = false,
        _onTap = onTap,
+       _actionSemanticsLabel = actionSemanticsLabel,
        _heroTag = heroTag;
 
   @override
@@ -162,6 +168,7 @@ class _GtSearchFieldState extends State<GtSearchField> {
       child = GtInkWell(
         onTap: widget._onTap,
         role: .button,
+        semanticsLabel: widget._actionSemanticsLabel,
         excludeDescendantSemantics: true,
         child: IgnorePointer(child: child),
       );

--- a/lib/widgets/molecules/inputs/gt_search_field.dart
+++ b/lib/widgets/molecules/inputs/gt_search_field.dart
@@ -97,12 +97,12 @@ class GtSearchField extends GtStatefulWidget {
     this.suffix,
     this.clearSemanticLabel,
     required OnPressed onTap,
-    String? actionSemanticsLabel,
+    String? semanticsLabel,
     String? heroTag,
   }) : _readonly = true,
        autoFocus = false,
        _onTap = onTap,
-       _actionSemanticsLabel = actionSemanticsLabel,
+       _actionSemanticsLabel = semanticsLabel,
        _heroTag = heroTag;
 
   @override

--- a/lib/widgets/molecules/inputs/gt_search_field.dart
+++ b/lib/widgets/molecules/inputs/gt_search_field.dart
@@ -68,9 +68,12 @@ class GtSearchField extends GtStatefulWidget {
     this.suffix,
     this.clearSemanticLabel,
     this.autoFocus = true,
-  }) : _readonly = false,
-       _onTap = null,
-       _heroTag = null;
+    OnPressed? onTap,
+    bool readonly = false,
+    String? heroTag,
+  }) : _readonly = readonly,
+       _onTap = onTap,
+       _heroTag = heroTag;
 
   /// Creates a read-only [GtSearchField] that acts as an interactive button to trigger an action (e.g. opening a search page or modal).
   ///

--- a/lib/widgets/molecules/inputs/gt_search_field.dart
+++ b/lib/widgets/molecules/inputs/gt_search_field.dart
@@ -44,7 +44,16 @@ class GtSearchField extends GtStatefulWidget {
   /// An optional semantic label for the clear button.
   final String? clearSemanticLabel;
 
-  /// Creates a new [GtSearchField].
+  /// Whether the field is in read-only action mode, initialized via [GtSearchField.forAction].
+  final bool _readonly;
+
+  /// The callback invoked when the field is tapped in action mode.
+  final OnPressed? _onTap;
+
+  /// An optional Hero animation tag used to animate transitions between screens.
+  final String? _heroTag;
+
+  /// Creates a standard editable [GtSearchField].
   const GtSearchField({
     super.key,
     this.controller,
@@ -59,7 +68,34 @@ class GtSearchField extends GtStatefulWidget {
     this.suffix,
     this.clearSemanticLabel,
     this.autoFocus = true,
-  });
+  }) : _readonly = false,
+       _onTap = null,
+       _heroTag = null;
+
+  /// Creates a read-only [GtSearchField] that acts as an interactive button to trigger an action (e.g. opening a search page or modal).
+  ///
+  /// Disables direct text editing, sets [autoFocus] to `false`, and triggers [onTap] when pressed.
+  /// An optional [heroTag] can be provided to participate in [Hero] route transitions.
+  const GtSearchField.forAction({
+    super.key,
+    this.controller,
+    this.validator,
+    this.hintText,
+    this.onChange,
+    this.isRequired = true,
+    this.decoration,
+    this.helperText,
+    this.isEnabled = true,
+    this.prefix,
+    this.suffix,
+    this.clearSemanticLabel,
+    required OnPressed onTap,
+    String? heroTag,
+  }) : _readonly = true,
+       autoFocus = false,
+       _onTap = onTap,
+       _heroTag = heroTag;
+
   @override
   State<GtSearchField> createState() => _GtSearchFieldState();
 }
@@ -102,7 +138,7 @@ class _GtSearchFieldState extends State<GtSearchField> {
         );
       },
     );
-    return GtTextField(
+    Widget child = GtTextField(
       isEnabled: widget.isEnabled,
       decoration: widget.decoration ?? context.inputStyles.searchDecoration,
       helperText: widget.helperText,
@@ -118,5 +154,23 @@ class _GtSearchFieldState extends State<GtSearchField> {
       textInputAction: .search,
       onChanged: widget.onChange,
     );
+
+    if (widget._readonly) {
+      child = GtInkWell(
+        onTap: widget._onTap,
+        role: .button,
+        excludeDescendantSemantics: true,
+        child: IgnorePointer(child: child),
+      );
+    }
+
+    if (widget._heroTag.hasValue) {
+      child = Material(
+        type: .transparency,
+        child: Hero(tag: widget._heroTag!, child: child),
+      );
+    }
+
+    return child;
   }
 }

--- a/lib/widgets/molecules/inputs/gt_signature_pad.dart
+++ b/lib/widgets/molecules/inputs/gt_signature_pad.dart
@@ -1,0 +1,457 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// A controller-driven drawing surface for capturing a customer's signature.
+///
+/// The drawing gesture is not an accessible input method for screen-reader or
+/// limited-mobility users. [onSecondaryAction] is therefore required and is
+/// exposed as a labelled, keyboard-reachable upload action.
+///
+/// {@category Molecules}
+class GtSignaturePad extends GtStatefulWidget {
+  /// Default canvas height from the onboarding signature design.
+  static const double defaultHeight = 207;
+
+  /// Default logical stroke width.
+  static const double defaultStrokeWidth = 2;
+
+  /// Controller that owns scribble, history, and encoded image state.
+  ///
+  /// When omitted, the widget creates and disposes an internal controller.
+  final GtSignaturePadController? controller;
+
+  /// Called after a completed drawing state is encoded, and with `null` when
+  /// an existing signature is cleared.
+  final OnChanged<Uint8List?>? onChanged;
+
+  /// Primary empty-state instruction.
+  final String title;
+
+  /// Supporting empty-state instruction.
+  final String subtitle;
+
+  /// Visual rendered inside the secondary action target.
+  ///
+  /// This is treated as presentation only; [onSecondaryAction] owns activation
+  /// and [secondaryActionSemanticLabel] owns its accessible name. It defaults
+  /// to the design-system upload-folder glyph.
+  final Widget? secondaryAction;
+
+  /// Opens the accessible alternative signature input, such as a file picker.
+  ///
+  /// When omitted, tapping the secondary action automatically opens the native
+  /// device image picker via [AppImagePlugin.pickImage].
+  final OnPressed? onSecondaryAction;
+
+  /// Accessible name announced for the secondary action.
+  final String secondaryActionSemanticLabel;
+
+  /// Height in design pixels, converted through `context.dp(height.px)`.
+  final double? height;
+
+  /// Signature stroke color. Defaults to the theme's strong text color.
+  final Color? strokeColor;
+
+  /// Canvas fill color. Defaults to the theme's soft background color.
+  final Color? backgroundColor;
+
+  /// Stroke width in design pixels, converted through `context.dp(width.px)`.
+  final double strokeWidth;
+
+  /// Called when the built-in clear action removes the current signature.
+  final OnPressed? onClear;
+
+  /// Whether drawing and history/upload actions are interactive.
+  final bool isEnabled;
+
+  /// Accessible name for the drawing surface.
+  final String semanticsLabel;
+
+  /// Accessible explanation of the drawing surface and its alternative.
+  final String semanticsHint;
+
+  /// Accessible name for the built-in undo action.
+  final String undoSemanticLabel;
+
+  /// Accessible name for the built-in redo action.
+  final String redoSemanticLabel;
+
+  /// Accessible name for the built-in clear action.
+  final String clearSemanticLabel;
+
+  /// Creates a signature pad.
+  const GtSignaturePad({
+    super.key,
+    this.controller,
+    this.onChanged,
+    required this.title,
+    required this.subtitle,
+    this.secondaryAction,
+    this.onSecondaryAction,
+    this.secondaryActionSemanticLabel = 'Upload a signature instead',
+    this.height,
+    this.strokeColor,
+    this.backgroundColor,
+    this.strokeWidth = defaultStrokeWidth,
+    this.onClear,
+    this.isEnabled = true,
+    required this.semanticsLabel,
+    required this.semanticsHint,
+    required this.undoSemanticLabel,
+    required this.redoSemanticLabel,
+    required this.clearSemanticLabel,
+  }) : assert(height == null || height > 0),
+       assert(strokeWidth > 0),
+       assert(title.length > 0),
+       assert(subtitle.length > 0),
+       assert(secondaryActionSemanticLabel.length > 0),
+       assert(semanticsLabel.length > 0),
+       assert(semanticsHint.length > 0),
+       assert(undoSemanticLabel.length > 0),
+       assert(redoSemanticLabel.length > 0),
+       assert(clearSemanticLabel.length > 0);
+
+  @override
+  State<GtSignaturePad> createState() => _GtSignaturePadState();
+}
+
+class _GtSignaturePadState extends State<GtSignaturePad> {
+  late GtSignaturePadController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _attachController(widget.controller ?? GtSignaturePadController());
+  }
+
+  @override
+  void didUpdateWidget(covariant GtSignaturePad oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller) return;
+
+    _controller.imageListenable.removeListener(_notifyImageChanged);
+    if (oldWidget.controller == null) _controller.dispose();
+    _attachController(widget.controller ?? GtSignaturePadController());
+  }
+
+  @override
+  void dispose() {
+    _controller.imageListenable.removeListener(_notifyImageChanged);
+    if (widget.controller == null) _controller.dispose();
+    super.dispose();
+  }
+
+  void _attachController(GtSignaturePadController controller) {
+    _controller = controller;
+    _controller.imageListenable.addListener(_notifyImageChanged);
+  }
+
+  void _notifyImageChanged() {
+    widget.onChanged?.call(_controller.bytes);
+  }
+
+  Offset _boundedPoint(Offset point, Size size) {
+    return Offset(
+      point.dx.clamp(0, size.width).toDouble(),
+      point.dy.clamp(0, size.height).toDouble(),
+    );
+  }
+
+  void _clear() {
+    if (!widget.isEnabled) return;
+    _controller.clear();
+    widget.onClear?.call();
+  }
+
+  Future<void> _handleSecondaryAction() async {
+    if (!widget.isEnabled) return;
+    if (widget.onSecondaryAction != null) {
+      widget.onSecondaryAction!();
+    } else {
+      await _controller.pickImage();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final canvasHeight =
+        widget.height ?? context.dp(GtSignaturePad.defaultHeight.px);
+    final canvasColor = widget.backgroundColor ?? palette.bg.soft;
+    final signatureColor = widget.strokeColor ?? palette.text.strong;
+
+    return GtDisabledOverlay(
+      !widget.isEnabled,
+      child: GtSizedBox(
+        width: double.infinity,
+        height: canvasHeight,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final canvasSize = constraints.biggest;
+            return Stack(
+              clipBehavior: Clip.hardEdge,
+              children: [
+                Positioned.fill(
+                  child: RepaintBoundary(
+                    key: _controller.repaintBoundaryKey,
+                    child: ColoredBox(
+                      color: canvasColor,
+                      child: Semantics(
+                        label: widget.semanticsLabel,
+                        hint: widget.semanticsHint,
+                        enabled: widget.isEnabled,
+                        child: MouseRegion(
+                          cursor: widget.isEnabled
+                              ? SystemMouseCursors.precise
+                              : SystemMouseCursors.forbidden,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onPanStart: widget.isEnabled
+                                ? (details) {
+                                    _controller.beginStroke(
+                                      _boundedPoint(
+                                        details.localPosition,
+                                        canvasSize,
+                                      ),
+                                    );
+                                  }
+                                : null,
+                            onPanUpdate: widget.isEnabled
+                                ? (details) {
+                                    _controller.appendPoint(
+                                      _boundedPoint(
+                                        details.localPosition,
+                                        canvasSize,
+                                      ),
+                                    );
+                                  }
+                                : null,
+                            onPanEnd: widget.isEnabled
+                                ? (_) => _controller.endStroke()
+                                : null,
+                            onPanCancel: widget.isEnabled
+                                ? _controller.endStroke
+                                : null,
+                            child: CustomPaint(
+                              painter: GtSignaturePainter(
+                                controller: _controller,
+                                strokeColor: signatureColor,
+                                strokeWidth: widget.strokeWidth,
+                              ),
+                              child: const SizedBox.expand(),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                GenericListener<GtSignaturePadValue>(
+                  valueListenable: _controller,
+                  builder: (state) {
+                    final image = state.image;
+                    if (image == null) return const SizedBox.shrink();
+                    return Positioned.fill(
+                      child: Padding(
+                        padding: context.insets.allDp(12.px),
+                        child: GtImage(
+                          image: AppImageData.bytes(image),
+                          fit: BoxFit.contain,
+                          isDecorative: true,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                GenericListener<GtSignaturePadValue>(
+                  valueListenable: _controller,
+                  builder: (state) {
+                    if (!state.isEmpty) return const SizedBox.shrink();
+                    return Positioned.fill(
+                      child: IgnorePointer(child: _Placeholder(widget: widget)),
+                    );
+                  },
+                ),
+                PositionedDirectional(
+                  start: 0,
+                  top: context.dp(context.spacing.xs.px),
+                  child: _SignatureActionTarget(
+                    semanticsLabel: widget.secondaryActionSemanticLabel,
+                    isEnabled: widget.isEnabled,
+                    onPressed: _handleSecondaryAction,
+                    child:
+                        widget.secondaryAction ??
+                        GtIcon(GtIcons.uploadFolder, size: context.dp(20.px)),
+                  ),
+                ),
+                GenericListener<GtSignaturePadValue>(
+                  valueListenable: _controller,
+                  builder: (state) {
+                    if (!state.canUndo && !state.canRedo && !state.isImage) {
+                      return const SizedBox.shrink();
+                    }
+                    return PositionedDirectional(
+                      end: context.dp(context.spacing.sm.px),
+                      top: 0,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (state.strokes.isNotEmpty ||
+                              state.redoStrokes.isNotEmpty) ...[
+                            _SignatureHistoryAction(
+                              icon: GtIcons.rotateAnticlockwise,
+                              semanticsLabel: widget.undoSemanticLabel,
+                              isEnabled: widget.isEnabled && state.canUndo,
+                              onPressed: _controller.undo,
+                            ),
+                            _SignatureHistoryAction(
+                              icon: GtIcons.rotateAnticlockwise,
+                              flipHorizontally: true,
+                              semanticsLabel: widget.redoSemanticLabel,
+                              isEnabled: widget.isEnabled && state.canRedo,
+                              onPressed: _controller.redo,
+                            ),
+                          ],
+                          _SignatureHistoryAction(
+                            icon: GtIcons.trash,
+                            semanticsLabel: widget.clearSemanticLabel,
+                            isEnabled: widget.isEnabled && state.hasSignature,
+                            onPressed: _clear,
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _Placeholder extends GtStatelessWidget {
+  final GtSignaturePad widget;
+
+  const _Placeholder({required this.widget});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: context.insets.symmetricDp(
+          horizontal: context.spacing.sectionMd.px,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GtText(
+              widget.title,
+              style: context.textStyles.subHeadS(
+                color: context.palette.text.strong,
+                weight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const GtGap.ySm(),
+            const GtGap.yXs(),
+            GtText(
+              widget.subtitle,
+              style: context.textStyles.subHeadXs(
+                color: context.palette.text.darkerSub,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SignatureActionTarget extends GtStatelessWidget {
+  final Widget child;
+  final String semanticsLabel;
+  final bool isEnabled;
+  final OnPressed onPressed;
+
+  const _SignatureActionTarget({
+    required this.child,
+    required this.semanticsLabel,
+    required this.isEnabled,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: context.dp(GtTapTarget.defaultMinSize.width.px),
+      child: GtInkWell(
+        role: .button,
+        semanticsLabel: semanticsLabel,
+        excludeDescendantSemantics: true,
+        isEnabled: isEnabled,
+        onTap: onPressed,
+        child: Center(child: ExcludeSemantics(child: child)),
+      ),
+    );
+  }
+}
+
+class _SignatureHistoryAction extends GtStatelessWidget {
+  final IconData icon;
+  final String semanticsLabel;
+  final bool isEnabled;
+  final OnPressed onPressed;
+  final bool flipHorizontally;
+
+  const _SignatureHistoryAction({
+    required this.icon,
+    required this.semanticsLabel,
+    required this.isEnabled,
+    required this.onPressed,
+    this.flipHorizontally = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    Widget iconWidget = GtIcon.withColor(
+      icon,
+      size: context.dp(14.px),
+      color: isEnabled ? palette.icon.sub : palette.icon.disabled,
+    );
+    if (flipHorizontally) {
+      iconWidget = Transform.flip(flipX: true, child: iconWidget);
+    }
+
+    return SizedBox.square(
+      dimension: context.dp(GtTapTarget.defaultMinSize.width.px),
+      child: Center(
+        child: SizedBox.square(
+          dimension: context.dp(28.px),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: palette.bg.weak,
+              shape: BoxShape.circle,
+            ),
+            child: GtInkWell(
+              role: .button,
+              semanticsLabel: semanticsLabel,
+              excludeDescendantSemantics: true,
+              isEnabled: isEnabled,
+              customBorder: const CircleBorder(),
+              onTap: onPressed,
+              child: Center(child: ExcludeSemantics(child: iconWidget)),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/molecules/inputs/inputs.dart
+++ b/lib/widgets/molecules/inputs/inputs.dart
@@ -11,6 +11,7 @@ export 'gt_password_field.dart';
 export 'gt_phone_field.dart';
 export 'gt_pin_input.dart';
 export 'gt_search_field.dart';
+export 'gt_signature_pad.dart';
 export 'gt_text_field.dart';
 export 'gt_transfer_field.dart';
 export 'gt_url_field.dart';

--- a/lib/widgets/molecules/tiles/gt_list_tile_template.dart
+++ b/lib/widgets/molecules/tiles/gt_list_tile_template.dart
@@ -82,11 +82,11 @@ class GtBaseListTileTemplate extends GtStatelessWidget {
       children: [
         title,
         if (subtitle != null) ...[
-          GtSizedBox(height: spacingToSubTitle ?? context.spacingXs),
+          SizedBox(height: spacingToSubTitle ?? context.spacingXs),
           subtitle!,
         ],
         if (footer != null) ...[
-          GtSizedBox(height: spacingToFooter ?? context.spacingSm),
+          SizedBox(height: spacingToFooter ?? context.spacingSm),
           footer!,
         ],
       ],

--- a/lib/widgets/molecules/tiles/gt_list_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_list_tiles.dart
@@ -203,6 +203,9 @@ class GtSimpleActionListTile extends GtStatelessWidget {
   /// The style of the title text.
   final TextStyle? titleStyle;
 
+  /// The style of the trailing icon.
+  final GtIconVariant? trailingIconVariant;
+
   /// Creates a [GtSimpleActionListTile].
   const GtSimpleActionListTile(
     this.title, {
@@ -212,6 +215,7 @@ class GtSimpleActionListTile extends GtStatelessWidget {
     this.padding,
     this.trailingIconSize,
     this.titleStyle,
+    this.trailingIconVariant,
   });
 
   @override
@@ -234,7 +238,7 @@ class GtSimpleActionListTile extends GtStatelessWidget {
             GtIcon(
               trailing,
               size: trailingIconSize ?? context.dp(20.px),
-              variant: .soft,
+              variant: trailingIconVariant ?? .soft,
               alignment: Alignment.centerRight,
             ),
           ],

--- a/lib/widgets/molecules/tiles/gt_list_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_list_tiles.dart
@@ -188,22 +188,30 @@ class GtSimpleActionListTile extends GtStatelessWidget {
   /// The primary title text.
   final String title;
 
-  /// The secondary text for the action tile.
-  final String subtitle;
-
   /// The icon to display at the end of the tile. Defaults to `GtIcons.chevronRight`.
   final IconData trailing;
 
   /// The callback triggered when the tile is tapped.
   final OnPressed? onTap;
 
+  /// The padding to apply to the tile.
+  final EdgeInsetsGeometry? padding;
+
+  /// The size of the trailing icon.
+  final double? trailingIconSize;
+
+  /// The style of the title text.
+  final TextStyle? titleStyle;
+
   /// Creates a [GtSimpleActionListTile].
   const GtSimpleActionListTile(
     this.title, {
     super.key,
-    required this.subtitle,
     this.trailing = GtIcons.chevronRight,
     this.onTap,
+    this.padding,
+    this.trailingIconSize,
+    this.titleStyle,
   });
 
   @override
@@ -213,14 +221,19 @@ class GtSimpleActionListTile extends GtStatelessWidget {
       borderRadius: context.borderRadius2Xl,
       onTap: onTap,
       child: Padding(
-        padding: context.insets.symmetricDp(vertical: 12.px),
+        padding: padding ?? context.insets.symmetricDp(vertical: 12.px),
         child: Row(
           spacing: context.spacingMd,
           children: [
-            Expanded(child: GtText(title, style: context.textStyles.h6())),
+            Expanded(
+              child: GtText(
+                title,
+                style: titleStyle ?? context.textStyles.h6(),
+              ),
+            ),
             GtIcon(
               trailing,
-              size: context.dp(20.px),
+              size: trailingIconSize ?? context.dp(20.px),
               variant: .soft,
               alignment: Alignment.centerRight,
             ),

--- a/lib/widgets/molecules/tiles/gt_status_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_status_tiles.dart
@@ -5,8 +5,8 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 /// A list tile that displays an illustration alongside a title and subtitle,
 /// often used for onboarding or multi-step processes.
 class GtIllustratedStepTile extends GtStatelessWidget {
-  /// The path to the SVG illustration displayed at the start of the tile.
-  final String illustrationPath;
+  /// The illustration image data displayed at the start of the tile.
+  final AppImageData illustration;
 
   /// The primary title text of the step.
   final String title;
@@ -16,38 +16,57 @@ class GtIllustratedStepTile extends GtStatelessWidget {
 
   /// Whether this step has been completed. If true, displays a success checkmark and visually disables the tile.
   final bool isDone;
+
+  /// Whether the tile should be rendered inside a [GtCard].
   final bool _asCard;
+
+  /// An optional custom width and height for the leading [illustration].
+  final double? illustrationSize;
+
+  /// An optional custom text style for the [title].
+  final TextStyle? titleStyle;
+
+  /// An optional custom text style for the [subtitle].
+  final TextStyle? subtitleStyle;
 
   /// Creates a standard [GtIllustratedStepTile].
   const GtIllustratedStepTile({
     super.key,
-    required this.illustrationPath,
+    required this.illustration,
     required this.title,
     required this.subtitle,
     this.isDone = false,
+    this.illustrationSize,
+    this.titleStyle,
+    this.subtitleStyle,
   }) : _asCard = false;
 
-  /// Creates a [GtIllustratedStepTile] wrapped in a stylized card.
+  /// Creates a [GtIllustratedStepTile] wrapped in a stylized [GtCard].
   const GtIllustratedStepTile.card({
     super.key,
-    required this.illustrationPath,
+    required this.illustration,
     required this.title,
     required this.subtitle,
     this.isDone = false,
+    this.illustrationSize,
+    this.titleStyle,
+    this.subtitleStyle,
   }) : _asCard = true;
 
   @override
   Widget build(BuildContext context) {
     final textColors = context.palette.text;
+    final iconSize = illustrationSize ?? context.dp(36.px);
+    final style = context.textStyles;
 
     Widget child = Row(
       spacing: context.spacingMd,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        GtSvg(
-          illustrationPath,
-          height: 36,
-          width: 36,
+        GtImage(
+          image: illustration,
+          width: iconSize,
+          height: iconSize,
           alignment: .topLeft,
           isDecorative: true,
         ),
@@ -55,10 +74,10 @@ class GtIllustratedStepTile extends GtStatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              GtText(title, style: context.textStyles.subHeadM()),
+              GtText(title, style: titleStyle ?? style.subHeadM()),
               GtText(
                 subtitle,
-                style: context.textStyles.subHeadXs(color: textColors.sub),
+                style: subtitleStyle ?? style.subHeadXs(color: textColors.sub),
               ),
             ],
           ),

--- a/lib/widgets/molecules/tiles/gt_user_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_user_tiles.dart
@@ -9,7 +9,7 @@ class GtAccountListTile extends GtStatelessWidget {
   final String title;
 
   /// Secondary information, typically the account type or currency.
-  final String subtitle;
+  final String? subtitle;
 
   /// An icon or avatar displayed at the start of the tile.
   final Widget leading;
@@ -29,17 +29,21 @@ class GtAccountListTile extends GtStatelessWidget {
   /// Optional style override for the [subtitle].
   final TextStyle? subtitleStyle;
 
+  /// Optional horizontal spacing override.
+  final double? horizontalSpacing;
+
   /// Creates a [GtAccountListTile].
   const GtAccountListTile(
     this.title, {
     super.key,
-    required this.subtitle,
+    this.subtitle,
     required this.leading,
     this.trailing,
     this.onTap,
     this.hasBoldSubtitle = true,
     this.titleStyle,
     this.subtitleStyle,
+    this.horizontalSpacing,
   });
 
   @override
@@ -57,21 +61,19 @@ class GtAccountListTile extends GtStatelessWidget {
       child: Padding(
         padding: context.insets.symmetricDp(vertical: 8.px),
         child: Row(
-          spacing: context.spacingMd,
+          spacing: horizontalSpacing ?? context.spacingMd,
           children: [
-            ConstrainedBox(
-              constraints: BoxConstraints.tight(Size.square(36)),
-              child: leading,
-            ),
+            leading,
             Expanded(
               child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+                crossAxisAlignment: .start,
                 children: [
                   GtText(
                     title,
                     style: titleStyle ?? context.textStyles.subHeadS(),
                   ),
-                  GtText(subtitle, style: subtitleStyle ?? defaultSubStyle),
+                  if (subtitle.hasValue)
+                    GtText(subtitle, style: subtitleStyle ?? defaultSubStyle),
                 ],
               ),
             ),
@@ -90,16 +92,22 @@ class GtContactListTile extends GtStatelessWidget {
   final String title;
 
   /// Secondary information, typically a username, email, or phone number.
-  final String subtitle;
+  final String? subtitle;
 
   /// An avatar or icon representing the contact.
   final Widget leading;
+
+  /// An optional widget displayed at the end of the tile (e.g., balance, chevron, or switch).
+  final Widget? trailing;
 
   /// The callback triggered when the tile is tapped. Provides light haptic feedback.
   final OnPressed onTap;
 
   /// An optional spacing between the title amd subtitle.
   final double? spacing;
+
+  /// Optional horizontal spacing override.
+  final double? horizontalSpacing;
 
   /// Creates a [GtContactListTile].
   const GtContactListTile(
@@ -108,13 +116,21 @@ class GtContactListTile extends GtStatelessWidget {
     required this.subtitle,
     required this.leading,
     required this.onTap,
+    this.trailing,
     this.spacing,
+    this.horizontalSpacing,
   });
 
   @override
   Widget build(BuildContext context) {
     final palette = context.palette;
     final subStyle = context.textStyles.subHead2xs(color: palette.text.sub);
+    final traillingWidget = GtIcon(
+      GtIcons.chevronRight,
+      size: 14,
+      alignment: Alignment.centerRight,
+      variant: .soft,
+    );
 
     return GtInkWell(
       role: .button,
@@ -123,28 +139,20 @@ class GtContactListTile extends GtStatelessWidget {
       child: Padding(
         padding: context.insets.symmetricDp(vertical: 8.px),
         child: Row(
-          spacing: context.spacingBase,
+          spacing: horizontalSpacing ?? context.spacingBase,
           children: [
-            ConstrainedBox(
-              constraints: BoxConstraints.tight(Size.square(36)),
-              child: leading,
-            ),
+            leading,
             Expanded(
               child: Column(
                 crossAxisAlignment: .start,
                 spacing: spacing ?? 0,
                 children: [
                   GtText(title, style: context.textStyles.subHeadS()),
-                  GtText(subtitle, style: subStyle),
+                  if (subtitle.hasValue) GtText(subtitle, style: subStyle),
                 ],
               ),
             ),
-            GtIcon(
-              GtIcons.chevronRight,
-              size: 14,
-              alignment: Alignment.centerRight,
-              variant: .soft,
-            ),
+            trailing ?? traillingWidget,
           ],
         ),
       ),
@@ -186,8 +194,8 @@ class GtStakeHolderListTile extends GtStatelessWidget {
       crossAxisAlignment: .start,
       spacing: context.spacingBase,
       children: [
-        ConstrainedBox(
-          constraints: BoxConstraints.tight(Size.square(36)),
+        GtSquareConstrainedBox(
+          context.dp(36.px),
           child: DecoratedBox(
             decoration: BoxDecoration(
               shape: .circle,

--- a/lib/widgets/organisms/app_bars/gt_modal_app_bar.dart
+++ b/lib/widgets/organisms/app_bars/gt_modal_app_bar.dart
@@ -64,13 +64,16 @@ class GtModalAppBar extends GtStatelessWidget implements PreferredSizeWidget {
                   spacing: context.spacingSm,
                   children: [
                     ?_titleLeading,
-                    GtText(
-                      _title?.upper,
-                      style: context.textStyles.h6(),
-                      textAlign: .center,
-                      maxLines: 1,
-                      // Level 1 within the modal's own route scope.
-                      headingLevel: 1,
+                    Flexible(
+                      child: GtText(
+                        _title?.upper,
+                        style: context.textStyles.h6(),
+                        textAlign: .center,
+                        maxLines: 1,
+                        // Level 1 within the modal's own route scope.
+                        headingLevel: 1,
+                        overflow: .ellipsis,
+                      ),
                     ),
                   ],
                 ),
@@ -102,23 +105,27 @@ class _GtExtendedModalAppBar extends GtModalAppBar {
       type: .transparency,
       child: Padding(
         padding: context.insets.fromLTRBDp(16.px, 24.px, 16.px, 0),
-        child: Row(
+        child: Table(
+          defaultVerticalAlignment: .middle,
+          columnWidths: const {
+            0: FlexColumnWidth(2),
+            1: FlexColumnWidth(10),
+            2: FlexColumnWidth(2),
+          },
           children: [
-            GtBackButton(size: .small),
-            Expanded(
-              child: FractionalTranslation(
-                // Slight horizontal offset to balance the visual center of the title
-                // against the leading back button.
-                translation: Offset(.08, 0),
-                child: GtText(
+            TableRow(
+              children: [
+                GtBackButton(size: .small),
+                GtText(
                   title,
                   textAlign: .center,
                   maxLines: 1,
                   style: context.textStyles.button(),
+                  overflow: .ellipsis,
                 ),
-              ),
+                Align(alignment: .centerRight, child: action),
+              ],
             ),
-            ?action,
           ],
         ),
       ),

--- a/lib/widgets/organisms/app_bars/gt_modal_app_bar.dart
+++ b/lib/widgets/organisms/app_bars/gt_modal_app_bar.dart
@@ -39,6 +39,13 @@ class GtModalAppBar extends GtStatelessWidget implements PreferredSizeWidget {
     Key? key,
   }) = _GtExtendedModalAppBar;
 
+  /// A [GtModalAppBar] that displays a title as a header, with an optional trailing action button. The title text is automatically expanded to fill available space and truncated with an ellipsis if necessary.
+  const factory GtModalAppBar.title({
+    required String title,
+    required Widget? action,
+    Key? key,
+  }) = _GtTitleModalAppBar;
+
   @override
   Widget build(BuildContext context) {
     return Material(
@@ -117,7 +124,7 @@ class _GtExtendedModalAppBar extends GtModalAppBar {
               children: [
                 GtBackButton(size: .small),
                 GtText(
-                  title,
+                  title.upper,
                   textAlign: .center,
                   maxLines: 1,
                   style: context.textStyles.button(),
@@ -126,6 +133,38 @@ class _GtExtendedModalAppBar extends GtModalAppBar {
                 Align(alignment: .centerRight, child: action),
               ],
             ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Internal implementation for the extended modal app bar.
+class _GtTitleModalAppBar extends GtModalAppBar {
+  final String title;
+  final Widget? action;
+
+  const _GtTitleModalAppBar({super.key, required this.title, this.action});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      type: .transparency,
+      child: Padding(
+        padding: context.insets.fromLTRBDp(16.px, 24.px, 16.px, 0),
+        child: Row(
+          spacing: context.spacingMd,
+          children: [
+            Expanded(
+              child: GtText(
+                title.upper,
+                maxLines: 1,
+                style: context.textStyles.button(),
+                overflow: .ellipsis,
+              ),
+            ),
+            ?action,
           ],
         ),
       ),

--- a/lib/widgets/organisms/cards/gt_help_card.dart
+++ b/lib/widgets/organisms/cards/gt_help_card.dart
@@ -22,6 +22,9 @@ class GtHelpCard extends GtStatelessWidget {
   /// The size of the icon. Default is 24
   final double? iconSize;
 
+  /// The icon to display in the help card. Default is [Icons.messages]
+  final IconData icon;
+
   /// Creates a [GtHelpCard].
   const GtHelpCard({
     super.key,
@@ -31,6 +34,7 @@ class GtHelpCard extends GtStatelessWidget {
     this.onTap,
     this.padding,
     this.iconSize,
+    this.icon = GtIcons.messages,
   });
 
   @override
@@ -65,7 +69,7 @@ class GtHelpCard extends GtStatelessWidget {
           crossAxisAlignment: .center,
           title: GtText(title, style: context.textStyles.bodyM()),
           leading: GtIcon.withColor(
-            GtIcons.messages,
+            icon,
             size: iconSize ?? 24,
             color: iconColor,
           ),

--- a/lib/widgets/organisms/cards/gt_help_card.dart
+++ b/lib/widgets/organisms/cards/gt_help_card.dart
@@ -70,7 +70,7 @@ class GtHelpCard extends GtStatelessWidget {
           title: GtText(title, style: context.textStyles.bodyM()),
           leading: GtIcon.withColor(
             icon,
-            size: iconSize ?? 24,
+            size: iconSize ?? context.dp(24.px),
             color: iconColor,
           ),
         ),

--- a/lib/widgets/organisms/cards/gt_state_cards.dart
+++ b/lib/widgets/organisms/cards/gt_state_cards.dart
@@ -14,31 +14,71 @@ class GtEmptyStateCard extends GtStatelessWidget {
   /// Defaults to [GtCardVariant.normal].
   final GtCardVariant variant;
 
+  /// A widget to display above the description. If null, no widget is shown.
+  final Widget? image;
+
+  /// A widget to display above the description. If null, no widget is shown.
+  final Widget? footer;
+
+  /// The space between the icon and the description. Defaults to [context.spacingBase].
+  final double? spacing;
+
+  /// The padding to apply to the card. Defaults to [context.insets.symmetricDp(vertical: 24.px, horizontal: 16.px)].
+  final EdgeInsetsGeometry? padding;
+
+  /// The text style to apply to the description. Defaults to [context.textStyles.subHeadXs(color: context.palette.text.sub)].
+  final TextStyle? style;
+
+  /// The size of the icon. Defaults to 24.
+  final double? iconSize;
+
   /// Creates a [GtEmptyStateCard].
   const GtEmptyStateCard({
     super.key,
     required this.icon,
     required this.description,
     this.variant = .normal,
-  });
+    this.spacing,
+    this.padding,
+    this.footer,
+    this.iconSize,
+    this.style,
+  }) : image = null;
+
+  const GtEmptyStateCard.image({
+    super.key,
+    required this.image,
+    required this.description,
+    this.spacing,
+    this.padding,
+    this.variant = .normal,
+    this.footer,
+    this.style,
+  }) : icon = null,
+       iconSize = null;
 
   @override
   Widget build(BuildContext context) {
+    final defaultPadding = context.insets.symmetricDp(
+      vertical: 24.px,
+      horizontal: 16.px,
+    );
+    final defaultStyle = context.textStyles.subHeadXs(
+      color: context.palette.text.sub,
+    );
+    final defaultIconSize = context.dp(24.px);
+
     return GtCard(
       variant: variant,
-      padding: context.insets.symmetricDp(vertical: 24.px, horizontal: 16.px),
+      padding: padding ?? defaultPadding,
       child: Column(
-        spacing: context.spacingBase,
+        spacing: spacing ?? context.spacingBase,
         mainAxisAlignment: .center,
         children: [
-          if (icon != null) GtIcon(icon!, size: 24),
-          GtText(
-            description,
-            style: context.textStyles.subHeadXs(
-              color: context.palette.text.sub,
-            ),
-            textAlign: .center,
-          ),
+          if (icon != null) GtIcon(icon!, size: iconSize ?? defaultIconSize),
+          ?image,
+          GtText(description, style: style ?? defaultStyle, textAlign: .center),
+          ?footer,
         ],
       ),
     );

--- a/lib/widgets/organisms/cards/gt_tip_card.dart
+++ b/lib/widgets/organisms/cards/gt_tip_card.dart
@@ -19,6 +19,12 @@ class GtTipCard extends GtStatelessWidget {
   /// A callback function that is invoked when the close button is tapped.
   final OnPressed onClose;
 
+  /// An optional custom text style for the [title].
+  final TextStyle? titleStyle;
+
+  /// An optional custom text style for the [subtitle].
+  final TextStyle? subtitleStyle;
+
   /// Creates a [GtTipCard].
   const GtTipCard({
     super.key,
@@ -27,6 +33,8 @@ class GtTipCard extends GtStatelessWidget {
     this.hidden = false,
     this.variant = .away,
     required this.onClose,
+    this.titleStyle,
+    this.subtitleStyle,
   });
 
   @override
@@ -34,6 +42,7 @@ class GtTipCard extends GtStatelessWidget {
     final palette = context.palette;
     final iconColor = variant.getIconColor(palette);
     final borderColor = variant.getBorderColor(palette);
+    final subStyle = context.textStyles.bodyXs(color: palette.text.darkerSub);
 
     return GtAnimatedFade(
       showFirst: !hidden,
@@ -62,7 +71,7 @@ class GtTipCard extends GtStatelessWidget {
                     spacing: context.spacingBase,
                     crossAxisAlignment: .start,
                     children: [
-                      Expanded(child: GtText(title)),
+                      Expanded(child: GtText(title, style: titleStyle)),
                       GtCancelButton(
                         onTap: onClose,
                         size: .xSmall,
@@ -70,12 +79,7 @@ class GtTipCard extends GtStatelessWidget {
                       ),
                     ],
                   ),
-                  GtRichText(
-                    subtitle,
-                    style: context.textStyles.bodyXs(
-                      color: palette.text.darkerSub,
-                    ),
-                  ),
+                  GtRichText(subtitle, style: subtitleStyle ?? subStyle),
                 ],
               ),
             ),

--- a/lib/widgets/organisms/navigation/gt_bottom_navigation_bar.dart
+++ b/lib/widgets/organisms/navigation/gt_bottom_navigation_bar.dart
@@ -191,10 +191,39 @@ class GtAndroidBottomNavigationBar extends GtStatelessWidget {
 }
 
 /// iOS-style bottom navigation bar with:
-/// - blurred floating container
-/// - animated selected-tab highlight
+/// - blurred floating glass container
+/// - animated selected-tab highlight pill
 /// - optional trailing circular action button
+///
+/// Geometry is transcribed 1:1 from the Figma spec (`Floating Nav Bar`,
+/// node `26743:67467`) and expressed in design pixels via [num.px] so
+/// [BuildContext.dp] can scale it down on narrower devices.
 class _GtIosFloatingBottomNavigationBar extends GtStatelessWidget {
+  /// Height of the glass pill and of the trailing circular action.
+  static const _barHeight = 58.0;
+
+  /// Gap between the glass edge and the tab row, i.e. the vertical breathing
+  /// room around the selection pill.
+  static const _glassInsetY = 4.0;
+
+  /// Gap between the glass edge and the first/last tab.
+  static const _glassInsetX = 6.0;
+
+  /// Visible gap between the tab pill and the trailing action.
+  static const _actionGap = 10.0;
+
+  /// Screen edge padding either side of the bar.
+  static const _screenInsetX = 16.0;
+
+  /// Padding between the bar and the home indicator / screen bottom.
+  static const _screenInsetY = 12.0;
+
+  /// Tab icon and trailing action icon size.
+  static const _iconSize = 24.0;
+
+  /// Horizontal padding inside a tab, which is what truncates long labels.
+  static const _tabInsetX = 8.0;
+
   final List<GtBottomNavigationItem> items;
   final int currentIndex;
   final ValueChanged<int> onIndexChanged;
@@ -215,126 +244,181 @@ class _GtIosFloatingBottomNavigationBar extends GtStatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = context.palette;
-    final radius = context.borderRadiusFull;
-
-    final boxDecoration = BoxDecoration(
-      color: palette.bg.strong.setOpacity(.01),
-      borderRadius: radius,
-      border: Border.all(color: palette.bg.white.setOpacity(.65)),
-      boxShadow: context.shadows.bottomNavInnerGlass(),
-    );
-
-    return Stack(
-      alignment: .bottomCenter,
-      children: [
-        SafeArea(
-          top: false,
-          bottom: context.isAndroid,
-          maintainBottomViewPadding: true,
-          minimum: context.insets.onlyDp(bottom: context.isAndroid ? 8.px : 0),
-          child: Container(
-            constraints: BoxConstraints(maxHeight: context.dp(95.px)),
-            padding: context.insets.fromLTRBDp(16.px, 0, 16.px, 21.px),
-            child: Row(
-              crossAxisAlignment: .center,
-              mainAxisSize: .min,
-              children: [
-                Expanded(
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      boxShadow: context.isInDarkMode
-                          ? context.shadows.md(context.palette.bg.weak)
-                          : context.shadows.bottomNavShadow(),
-                      borderRadius: radius,
+    return SafeArea(
+      top: false,
+      // The bar floats above the home indicator rather than under it, so the
+      // last tab stays reachable and the glass edge is not clipped by the
+      // system gesture area.
+      maintainBottomViewPadding: true,
+      child: Padding(
+        padding: context.insets.fromLTRBDp(
+          _screenInsetX.px,
+          0,
+          _screenInsetX.px,
+          _screenInsetY.px,
+        ),
+        child: SizedBox(
+          height: context.dp(_barHeight.px),
+          child: Row(
+            crossAxisAlignment: .stretch,
+            children: [
+              Expanded(
+                child: _GtBottomNavigationGlass(
+                  child: Padding(
+                    padding: context.insets.symmetricDp(
+                      horizontal: _glassInsetX.px,
+                      vertical: _glassInsetY.px,
                     ),
-                    child: ClipRRect(
-                      borderRadius: radius,
-                      child: BackdropFilter(
-                        filter: context.backdropFilters.bottomNavFrost(),
-                        child: Container(
-                          clipBehavior: .hardEdge,
-                          height: context.dp(68.px),
-                          decoration: boxDecoration,
-                          child: Stack(
-                            children: [
-                              Positioned.fill(
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    color: palette.bg.strong.withValues(
-                                      alpha: 0.01,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              LayoutBuilder(
-                                builder: (context, constraints) {
-                                  final tabWidth =
-                                      constraints.maxWidth / items.length;
-                                  final inset = context.dp(4.px);
-                                  final highlightHeight =
-                                      constraints.maxHeight - (2 * inset);
-
-                                  return Stack(
-                                    clipBehavior: .hardEdge,
-                                    children: [
-                                      AnimatedPositioned(
-                                        duration: enableSelectionAnimation
-                                            ? GtMotion.adaptiveDuration(
-                                                context,
-                                                GtMotion.fluid,
-                                              )
-                                            : Duration.zero,
-                                        curve: GtSpringCurves.snappy,
-                                        left: (tabWidth * currentIndex) + inset,
-                                        top: inset,
-                                        width: tabWidth - (2 * inset),
-                                        height: highlightHeight,
-                                        child: DecoratedBox(
-                                          decoration: BoxDecoration(
-                                            color: palette.fill.sub,
-                                            borderRadius: radius,
-                                          ),
-                                        ),
-                                      ),
-                                      Row(
-                                        children: [
-                                          for (final (i, item) in items.indexed)
-                                            Expanded(
-                                              child: _GtBottomNavigationTab(
-                                                item: item,
-                                                selected: i == currentIndex,
-                                                onTap: () => onIndexChanged(i),
-                                                enableSelectionAnimation:
-                                                    enableSelectionAnimation,
-                                              ),
-                                            ),
-                                        ],
-                                      ),
-                                    ],
-                                  );
-                                },
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
+                    child: _GtBottomNavigationTabs(
+                      items: items,
+                      currentIndex: currentIndex,
+                      onIndexChanged: onIndexChanged,
+                      iconSize: _iconSize,
+                      tabInsetX: _tabInsetX,
+                      enableSelectionAnimation: enableSelectionAnimation,
                     ),
                   ),
                 ),
-                if (onTrailingTap != null) ...[
-                  SizedBox(width: context.dp(12.px)),
-                  _GtBottomNavigationTrailingAction(
-                    onTap: onTrailingTap!,
-                    icon: trailingIcon,
-                    semanticsLabel: trailingSemanticsLabel,
-                  ),
-                ],
+              ),
+              if (onTrailingTap != null) ...[
+                SizedBox(width: context.dp(_actionGap.px)),
+                _GtBottomNavigationTrailingAction(
+                  onTap: onTrailingTap!,
+                  icon: trailingIcon,
+                  iconSize: _iconSize,
+                  size: _barHeight,
+                  semanticsLabel: trailingSemanticsLabel,
+                ),
               ],
-            ),
+            ],
           ),
         ),
-      ],
+      ),
+    );
+  }
+}
+
+/// The frosted glass surface shared by the tab pill and the trailing action.
+///
+/// Reproduces the Figma `Fill + Shadow` layer: a 65% [GtPaletteBgColors.white]
+/// fill over a blurred backdrop, an inner highlight along the edge, and a soft
+/// drop shadow. Every layer resolves through the palette, so the surface
+/// inverts with the theme instead of staying light in dark mode.
+class _GtBottomNavigationGlass extends GtStatelessWidget {
+  final Widget child;
+  final BoxShape shape;
+
+  const _GtBottomNavigationGlass({
+    required this.child,
+    this.shape = BoxShape.rectangle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final radius = context.borderRadiusFull;
+    final isCircle = shape == BoxShape.circle;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: shape,
+        borderRadius: isCircle ? null : radius,
+        boxShadow: context.isInDarkMode
+            ? context.shadows.md(palette.bg.weak)
+            : context.shadows.bottomNavShadow(),
+      ),
+      child: ClipRRect(
+        borderRadius: radius,
+        child: BackdropFilter(
+          filter: context.backdropFilters.bottomNavFrost(),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: palette.bg.white.setOpacity(.65),
+              borderRadius: radius,
+              boxShadow: context.shadows.bottomNavInnerGlass(),
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The tab row plus the selection pill that slides behind the active tab.
+class _GtBottomNavigationTabs extends GtStatelessWidget {
+  final List<GtBottomNavigationItem> items;
+  final int currentIndex;
+  final ValueChanged<int> onIndexChanged;
+  final double iconSize;
+  final double tabInsetX;
+  final bool enableSelectionAnimation;
+
+  const _GtBottomNavigationTabs({
+    required this.items,
+    required this.currentIndex,
+    required this.onIndexChanged,
+    required this.iconSize,
+    required this.tabInsetX,
+    required this.enableSelectionAnimation,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = context.borderRadiusFull;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final tabWidth = constraints.maxWidth / items.length;
+
+        return Stack(
+          clipBehavior: .hardEdge,
+          // Passthrough hands the incoming tight height down to the tab row.
+          // Under the default loose fit the row shrink-wraps its icon+label and
+          // Stack pins it to topStart, so the content rides the top of the pill
+          // instead of sitting in the middle of it.
+          fit: .passthrough,
+          children: [
+            // The pill spans the full height and width of a tab slot, so the
+            // icon and label sit centred inside it rather than floating above
+            // a smaller chip.
+            AnimatedPositioned(
+              duration: enableSelectionAnimation
+                  ? GtMotion.adaptiveDuration(context, GtMotion.fluid)
+                  : Duration.zero,
+              curve: GtSpringCurves.snappy,
+              left: tabWidth * currentIndex,
+              top: 0,
+              bottom: 0,
+              width: tabWidth,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: context.palette.fill.weak,
+                  borderRadius: radius,
+                ),
+              ),
+            ),
+            Row(
+              // Each tab fills the pill height so the whole pill is tappable,
+              // not just the icon and label.
+              crossAxisAlignment: .stretch,
+              children: [
+                for (final (i, item) in items.indexed)
+                  Expanded(
+                    child: _GtBottomNavigationTab(
+                      item: item,
+                      selected: i == currentIndex,
+                      iconSize: iconSize,
+                      insetX: tabInsetX,
+                      onTap: () => onIndexChanged(i),
+                      enableSelectionAnimation: enableSelectionAnimation,
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        );
+      },
     );
   }
 }
@@ -346,11 +430,18 @@ class GtBottomNavIcon extends GtStatelessWidget {
   final Color selectedColor;
   final bool enableSelectionAnimation;
 
+  /// Icon size in design pixels; scaled through [BuildContext.dp].
+  ///
+  /// Defaults to the Android bar's 28, the iOS bar passes the 24 its Figma
+  /// spec calls for.
+  final double size;
+
   const GtBottomNavIcon(
     this.icon, {
     required this.selected,
     required this.unselectedColor,
     required this.selectedColor,
+    this.size = 28,
     this.enableSelectionAnimation = true,
     super.key,
   });
@@ -365,7 +456,7 @@ class GtBottomNavIcon extends GtStatelessWidget {
       child: GtIcon.withColor(
         icon,
         key: ValueKey((icon, selected)),
-        size: context.dp(28.px),
+        size: context.dp(size.px),
         color: switch (selected) {
           true => selectedColor,
           _ => unselectedColor,
@@ -379,12 +470,16 @@ class GtBottomNavIcon extends GtStatelessWidget {
 class _GtBottomNavigationTab extends GtStatelessWidget {
   final GtBottomNavigationItem item;
   final bool selected;
+  final double iconSize;
+  final double insetX;
   final OnPressed onTap;
   final bool enableSelectionAnimation;
 
   const _GtBottomNavigationTab({
     required this.item,
     required this.selected,
+    required this.iconSize,
+    required this.insetX,
     required this.onTap,
     required this.enableSelectionAnimation,
   });
@@ -392,6 +487,19 @@ class _GtBottomNavigationTab extends GtStatelessWidget {
   @override
   Widget build(BuildContext context) {
     final palette = context.palette;
+
+    // The design's selected tones (`primary.dark` / `primary.darker`) are fixed
+    // teals tuned against the light pill. On the dark pill they sink into the
+    // background — `primary.darker` lands near 1.2:1 — so dark mode steps up to
+    // the light brand tone instead of inheriting an unreadable label.
+    final isDark = context.isInDarkMode;
+    final selectedIconColor = isDark
+        ? palette.primary.base
+        : palette.primary.dark;
+    final selectedLabelColor = isDark
+        ? palette.primary.base
+        : palette.primary.darker;
+
     return GtInkWell(
       // GestureDetector takes no focus and reports no semantics, so this tab
       // was unreachable by screen readers, keyboards, and switch control.
@@ -400,24 +508,29 @@ class _GtBottomNavigationTab extends GtStatelessWidget {
       semanticsLabel: item.label,
       excludeDescendantSemantics: true,
       onTap: () => onTap(),
-      child: Center(
+      child: Padding(
+        padding: context.insets.symmetricDp(horizontal: insetX.px),
         child: Column(
-          mainAxisSize: .min,
           mainAxisAlignment: .center,
           crossAxisAlignment: .center,
           children: [
             GtBottomNavIcon(
               selected ? item.selectedIcon : item.unselectedIcon,
               selected: selected,
-              selectedColor: palette.primary.dark,
+              size: iconSize,
+              selectedColor: selectedIconColor,
               unselectedColor: palette.icon.sub,
               enableSelectionAnimation: enableSelectionAnimation,
             ),
             GtText(
               item.label,
+              // The bar has a fixed height, so a wrapped label would overflow
+              // the glass rather than push it taller.
+              maxLines: 1,
+              overflow: .ellipsis,
               textAlign: TextAlign.center,
               style: context.textStyles.navBarLabel(
-                color: selected ? palette.primary.darker : palette.text.soft,
+                color: selected ? selectedLabelColor : palette.text.darkerSub,
               ),
             ),
           ],
@@ -430,51 +543,31 @@ class _GtBottomNavigationTab extends GtStatelessWidget {
 class _GtBottomNavigationTrailingAction extends GtStatelessWidget {
   final OnPressed onTap;
   final IconData icon;
+  final double iconSize;
+  final double size;
   final String? semanticsLabel;
 
   const _GtBottomNavigationTrailingAction({
     required this.onTap,
     required this.icon,
+    required this.iconSize,
+    required this.size,
     required this.semanticsLabel,
   });
 
   @override
   Widget build(BuildContext context) {
-    final palette = context.palette;
-    final radius = context.borderRadiusFull;
-
-    final boxDecoration = BoxDecoration(
-      color: palette.bg.strong.setOpacity(.02),
-      borderRadius: radius,
-      border: Border.all(color: palette.bg.white.setOpacity(.65)),
-      boxShadow: context.shadows.bottomNavInnerGlass(),
-    );
-
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        boxShadow: context.isInDarkMode
-            ? context.shadows.md(context.palette.bg.weak)
-            : context.shadows.bottomNavShadow(),
-        shape: .circle,
-      ),
-      child: ClipRRect(
-        borderRadius: radius,
-        child: BackdropFilter(
-          filter: context.backdropFilters.bottomNavFrost(),
-          child: GtInkWell(
-            // GestureDetector takes no focus and reports no semantics.
-            role: .button,
-            semanticsLabel: semanticsLabel,
-            excludeDescendantSemantics: true,
-            onTap: () => onTap(),
-            child: Container(
-              alignment: .center,
-              height: context.dp(68.px),
-              width: context.dp(68.px),
-              decoration: boxDecoration,
-              child: Center(child: GtIcon(icon, size: context.dp(28.px))),
-            ),
-          ),
+    return _GtBottomNavigationGlass(
+      shape: .circle,
+      child: GtInkWell(
+        // GestureDetector takes no focus and reports no semantics.
+        role: .button,
+        semanticsLabel: semanticsLabel,
+        excludeDescendantSemantics: true,
+        onTap: () => onTap(),
+        child: SizedBox.square(
+          dimension: context.dp(size.px),
+          child: Center(child: GtIcon(icon, size: context.dp(iconSize.px))),
         ),
       ),
     );

--- a/lib/widgets/organisms/view_state/gt_status_state.dart
+++ b/lib/widgets/organisms/view_state/gt_status_state.dart
@@ -84,6 +84,11 @@ class GtStatusState extends GtStatelessWidget {
   /// The text style for the subtitle.
   final TextStyle? subtitleStyle;
 
+  /// The spacing between the title and the subtitle.
+  ///
+  /// Defaults to `GtGap.yMd()`. Can be customized with a [GtViewStateSpacer].
+  final GtViewStateSpacer? gapToTitle;
+
   /// Creates a [GtStatusState] configured for the given [variant] and copy.
   const GtStatusState({
     super.key,
@@ -95,6 +100,7 @@ class GtStatusState extends GtStatelessWidget {
     this.actionLabel,
     this.onActionPressed,
     this.actionVariant = .primary,
+    this.gapToTitle,
     this.gapToSubtitle = const GtViewStateGapSpacer(GtGap.yMd()),
     this.gapToAction = const GtViewStateGapSpacer(GtGap.yLg()),
     this.actionSize = .medium,
@@ -121,6 +127,7 @@ class GtStatusState extends GtStatelessWidget {
     this.actionLabel,
     this.onActionPressed,
     this.actionVariant = .primary,
+    this.gapToTitle,
     this.gapToSubtitle = const GtViewStateGapSpacer(GtGap.yMd()),
     this.gapToAction = const GtViewStateGapSpacer(GtGap.yLg()),
     this.actionSize = .medium,
@@ -144,6 +151,7 @@ class GtStatusState extends GtStatelessWidget {
     this.actionLabel,
     this.onActionPressed,
     this.actionVariant = .primary,
+    this.gapToTitle,
     this.gapToSubtitle = const GtViewStateGapSpacer(GtGap.yMd()),
     this.gapToAction = const GtViewStateGapSpacer(GtGap.yLg()),
     this.actionSize = .medium,
@@ -170,6 +178,7 @@ class GtStatusState extends GtStatelessWidget {
     this.actionLabel,
     this.onActionPressed,
     this.actionVariant = .primary,
+    this.gapToTitle,
     this.gapToSubtitle = const GtViewStateGapSpacer(GtGap.yMd()),
     this.gapToAction = const GtViewStateGapSpacer(GtGap.yLg()),
     this.actionSize = .medium,
@@ -213,6 +222,7 @@ class GtStatusState extends GtStatelessWidget {
       actionSize: actionSize,
       actionAlignment: actionAlignment,
       alignment: alignment ?? .center,
+      gapToTitle: gapToTitle,
       gapToDescription: gapToSubtitle,
       gapToAction: gapToAction,
       titleStyle: titleStyle,

--- a/lib/widgets/templates/forms/gt_virtual_keypad_form.dart
+++ b/lib/widgets/templates/forms/gt_virtual_keypad_form.dart
@@ -11,6 +11,7 @@ class GtVirtualKeypadForm extends GtStatefulWidget {
   /// The main heading text displayed at the top of the form.
   final String title;
 
+  /// The subtitle text displayed below the title in the default layout.
   final String? _subtitle;
 
   /// Optional helper text displayed below the input dots.
@@ -19,6 +20,7 @@ class GtVirtualKeypadForm extends GtStatefulWidget {
   /// Optional error text displayed below the input dots. Overrides helper text.
   final String? errorText;
 
+  /// Optional callback invoked when the biometric authentication button is tapped.
   final OnPressed? _onBioAuth;
 
   /// Controls the text being edited by the virtual keypad.
@@ -27,7 +29,11 @@ class GtVirtualKeypadForm extends GtStatefulWidget {
   /// An optional method that validates the input.
   final OnValidate<String?>? validator;
 
+  /// The avatar image displayed above the user's name in [GtVirtualKeypadForm.withAvatar].
   final AppImageData? _avatar;
+
+  /// An optional question-and-action button displayed below the header/avatar section and above the input dots.
+  final GtQuestionTextButton? headerQuestionButton;
 
   /// The maximum number of characters allowed in the input.
   final int maxLength;
@@ -80,12 +86,14 @@ class GtVirtualKeypadForm extends GtStatefulWidget {
     OnPressed? onBioAuth,
   }) : _subtitle = subtitle,
        _onBioAuth = onBioAuth,
+       headerQuestionButton = null,
        _avatar = null;
 
   /// Creates a virtual keypad form customized for user authentication.
   ///
-  /// Displays an [avatar] and uses [name] as the title. It also supports an
-  /// optional [onBioAuth] callback to enable biometric authentication from the keypad.
+  /// Displays an [avatar], uses [name] as the user heading, and supports an optional
+  /// [headerQuestionButton] (e.g. "Not you? Switch account") as well as an optional
+  /// [onBioAuth] callback to enable biometric authentication from the keypad.
   GtVirtualKeypadForm.withAvatar({
     super.key,
     required String name,
@@ -104,6 +112,7 @@ class GtVirtualKeypadForm extends GtStatefulWidget {
     this.action,
     this.color,
     this.inactiveColor,
+    this.headerQuestionButton,
   }) : _subtitle = null,
        _onBioAuth = onBioAuth,
        title = name,
@@ -151,24 +160,29 @@ class _GtVirtualKeypadFormState extends State<GtVirtualKeypadForm> {
                   subtitle: widget.subtitle,
                   spacingPx: context.spacing.md,
                 ),
-                GtGap.ySection3xl(),
-                GtGap.yBase(),
+                const GtGap.ySection3xl(),
+                const GtGap.yBase(),
               ] else ...[
-                GtGap.ySectionSm(),
+                const GtGap.ySectionSm(),
                 GtAvatar(
                   avatar: widget.avatar,
                   size: context.dp(64.px),
                   isUserAvatar: true,
                 ),
-                GtGap.ySectionSm(),
+                const GtGap.ySectionSm(),
                 GtText(
                   widget.title.upper,
-                  style: context.textStyles.h5(),
+                  style: context.textStyles.h5(heightPx: 24),
                   maxLines: 1,
                   textAlign: .center,
                 ),
-                GtGap.ySection3xl(),
               ],
+              if (widget.headerQuestionButton case Widget qb) ...[
+                const GtGap.yMd(),
+                qb,
+                const GtGap.ySectionXl(),
+              ] else
+                const GtGap.ySection3xl(),
               GtDotFormField(
                 controller: widget.controller,
                 length: widget.maxLength,

--- a/lib/widgets/templates/modals/gt_bottom_modal.dart
+++ b/lib/widgets/templates/modals/gt_bottom_modal.dart
@@ -321,7 +321,7 @@ class _GtModalBody extends GtStatelessWidget {
                 mainAxisSize: .min,
                 crossAxisAlignment: .center,
                 children: [
-                  const _GtBottomModalHandle(),
+                  const GtBottomModalHandle(),
                   ?icon,
                   const GtGap.yBase(),
                   Flexible(
@@ -396,7 +396,7 @@ class _GtModalBodyWithChild extends GtStatelessWidget {
             mainAxisSize: .min,
             crossAxisAlignment: .center,
             children: [
-              const _GtBottomModalHandle(),
+              const GtBottomModalHandle(),
               Flexible(child: child),
             ],
           ),
@@ -451,8 +451,8 @@ class _GtBottomModalIconWidget extends StatelessWidget {
 }
 
 /// Renders the top drag handle pill for the modal.
-class _GtBottomModalHandle extends StatelessWidget {
-  const _GtBottomModalHandle();
+class GtBottomModalHandle extends StatelessWidget {
+  const GtBottomModalHandle({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/templates/scaffolds/gt_dashboard_scaffold.dart
+++ b/lib/widgets/templates/scaffolds/gt_dashboard_scaffold.dart
@@ -69,6 +69,18 @@ class GtDashboardScaffold extends GtStatefulWidget {
   ///The style of the bottom navigation bar.
   final GtBottomNavigationStyle? bottomNavigationStyle;
 
+  /// An accessible name for the trailing action, already localised.
+  ///
+  /// The action is icon-only, so without a name a screen reader announces it
+  /// as an unlabelled button.
+  final String? trailingSemanticsLabel;
+
+  /// Whether the selection highlight and icon change should animate.
+  final bool enableSelectionAnimation;
+
+  /// Optional icon for the trailing action button (**iOS only**).
+  final IconData trailingIcon;
+
   /// Creates a [GtDashboardScaffold].
   const GtDashboardScaffold({
     super.key,
@@ -78,6 +90,9 @@ class GtDashboardScaffold extends GtStatefulWidget {
     required this.onClickHelp,
     this.pageController,
     this.bottomNavigationStyle,
+    this.trailingSemanticsLabel,
+    this.enableSelectionAnimation = true,
+    this.trailingIcon = GtIcons.helpInfo,
   }) : assert(data.length >= 2, "Data must be at least 2");
 
   @override
@@ -145,6 +160,9 @@ class _GtDashboardScaffoldState extends State<GtDashboardScaffold> {
               style: widget.bottomNavigationStyle,
               onTrailingTap: widget.onClickHelp,
               currentIndex: index,
+              trailingSemanticsLabel: widget.trailingSemanticsLabel,
+              enableSelectionAnimation: widget.enableSelectionAnimation,
+              trailingIcon: widget.trailingIcon,
               onIndexChanged: (index) {
                 if (navItems[index].onSelected != null) {
                   navItems[index].onSelected!(index);

--- a/test/gt_marquee_scroll_physics_test.dart
+++ b/test/gt_marquee_scroll_physics_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+void main() {
+  group('GtMarqueeScrollPhysics', () {
+    test('creates correct ballistic simulation when content overflows', () {
+      const physics = GtMarqueeScrollPhysics(
+        marqueeVelocity: 20.0,
+        pauseDuration: Duration(seconds: 1),
+      );
+
+      final position = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 100,
+        pixels: 0,
+        viewportDimension: 50,
+        axisDirection: AxisDirection.right,
+        devicePixelRatio: 1,
+      );
+
+      // At start -> targets maxScrollExtent (100)
+      final sim = physics.createBallisticSimulation(position, 0);
+      expect(sim, isNotNull);
+
+      // Initial pause at start
+      expect(sim!.x(0), equals(0));
+      expect(sim.x(0.5), equals(0));
+      expect(sim.dx(0.5), equals(0));
+      expect(sim.isDone(0.5), isFalse);
+
+      // Scrolling at velocity 20 px/s after 1s pause
+      // Total duration = 1s pause + (100px / 20px/s) = 6.0s
+      expect(sim.x(3.5), equals(50)); // (3.5 - 1.0) * 20 = 50
+      expect(sim.dx(3.5), equals(20));
+      expect(sim.x(6.0), equals(100));
+      expect(sim.isDone(6.0), isTrue);
+    });
+
+    test('reverses direction at maxScrollExtent to scroll back to start', () {
+      const physics = GtMarqueeScrollPhysics(
+        marqueeVelocity: 20.0,
+        pauseDuration: Duration(seconds: 1),
+      );
+
+      final position = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 100,
+        pixels: 100,
+        viewportDimension: 50,
+        axisDirection: AxisDirection.right,
+        devicePixelRatio: 1,
+      );
+
+      // At max -> targets minScrollExtent (0)
+      final sim = physics.createBallisticSimulation(position, 0);
+      expect(sim, isNotNull);
+
+      // Initial pause at max
+      expect(sim!.x(0), equals(100));
+      expect(sim.x(0.5), equals(100));
+      expect(sim.dx(0.5), equals(0));
+
+      // Scrolling back towards 0
+      expect(sim.x(3.5), equals(50)); // 100 - (2.5 * 20) = 50
+      expect(sim.dx(3.5), equals(-20));
+      expect(sim.x(6.0), equals(0));
+      expect(sim.isDone(6.0), isTrue);
+    });
+
+    test('returns null when content does not overflow', () {
+      const physics = GtMarqueeScrollPhysics();
+
+      final position = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 0,
+        pixels: 0,
+        viewportDimension: 100,
+        axisDirection: AxisDirection.right,
+        devicePixelRatio: 1,
+      );
+
+      final sim = physics.createBallisticSimulation(position, 0);
+      expect(sim, isNull);
+    });
+
+    test('adjustPositionForNewDimensions triggers ballistic kick off on initial layout', () {
+      const physics = GtMarqueeScrollPhysics();
+
+      final oldPosition = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 0,
+        pixels: 0,
+        viewportDimension: 100,
+        axisDirection: AxisDirection.right,
+        devicePixelRatio: 1,
+      );
+
+      final newPosition = FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 50,
+        pixels: 0,
+        viewportDimension: 100,
+        axisDirection: AxisDirection.right,
+        devicePixelRatio: 1,
+      );
+
+      final newPixels = physics.adjustPositionForNewDimensions(
+        oldPosition: oldPosition,
+        newPosition: newPosition,
+        isScrolling: false,
+        velocity: 0,
+      );
+
+      expect(newPixels, isNot(equals(0.0)));
+    });
+
+    testWidgets('SingleChildScrollView with GtMarqueeScrollPhysics scrolls back and forth', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 100,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                physics: const GtMarqueeScrollPhysics(
+                  marqueeVelocity: 50.0,
+                  pauseDuration: Duration(milliseconds: 500),
+                ),
+                child: const SizedBox(
+                  width: 300,
+                  height: 50,
+                  child: Text('Long overflowing marquee text that scrolls continuously'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final scrollable = find.byType(Scrollable);
+      expect(scrollable, findsOneWidget);
+
+      // Initial render: at 0
+      ScrollableState state = tester.state(scrollable);
+      expect(state.position.pixels, closeTo(0, 0.01));
+
+      // After 500ms pause: still around 0
+      await tester.pump(const Duration(milliseconds: 500));
+      state = tester.state(scrollable);
+      expect(state.position.pixels, closeTo(0, 0.01));
+
+      // After 2000ms: maxScrollExtent is 200 (300 - 100).
+      // Time to scroll 200px at 50px/s is 4s (4000ms).
+      // At 500ms pause + 2000ms scroll: pixels should be around 100.
+      await tester.pump(const Duration(milliseconds: 2000));
+      state = tester.state(scrollable);
+      expect(state.position.pixels, closeTo(100, 1.0));
+
+      // Complete forward scroll (total 500ms + 4000ms = 4500ms)
+      await tester.pump(const Duration(milliseconds: 2000));
+      state = tester.state(scrollable);
+      expect(state.position.pixels, closeTo(200, 1.0));
+
+      // Reversal: after end pause (500ms) and 2000ms backward scroll -> should be around 100
+      await tester.pump(const Duration(milliseconds: 2500));
+      state = tester.state(scrollable);
+      expect(state.position.pixels, closeTo(100, 1.0));
+
+      // Complete backward scroll -> back at 0
+      await tester.pump(const Duration(milliseconds: 2000));
+      state = tester.state(scrollable);
+      expect(state.position.pixels, closeTo(0, 1.0));
+    });
+  });
+}

--- a/test/gt_signature_pad_test.dart
+++ b/test/gt_signature_pad_test.dart
@@ -1,0 +1,321 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+class _FakeScreenShotService extends ScreenShotService {
+  final Uint8List image = Uint8List.fromList(<int>[
+    137,
+    80,
+    78,
+    71,
+    13,
+    10,
+    26,
+    10,
+    1,
+    2,
+    3,
+  ]);
+
+  @override
+  Future<Uint8List?> captureScreen(
+    BuildContext context, {
+    double? pixelRatio,
+    Duration delay = const Duration(milliseconds: 20),
+  }) async {
+    return Uint8List.fromList(image);
+  }
+}
+
+class _SignaturePadTestApp extends GtStatelessWidget {
+  final GtSignaturePadController controller;
+  final OnChanged<Uint8List?>? onChanged;
+  final OnPressed onSecondaryAction;
+  final OnPressed? onClear;
+
+  const _SignaturePadTestApp({
+    required this.controller,
+    required this.onSecondaryAction,
+    this.onChanged,
+    this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GtThemeProvider(
+      theme: kPersonalTheme,
+      child: MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: GtSignaturePad(
+              controller: controller,
+              title: 'Tap to draw your signature',
+              subtitle: 'Use your finger or a stylus to sign here',
+              onChanged: onChanged,
+              onSecondaryAction: onSecondaryAction,
+              secondaryActionSemanticLabel: 'Upload a signature instead',
+              semanticsLabel: 'Signature drawing area',
+              semanticsHint:
+                  'Draw with a finger or stylus, or use the upload signature action.',
+              undoSemanticLabel: 'Undo signature stroke',
+              redoSemanticLabel: 'Redo signature stroke',
+              clearSemanticLabel: 'Clear signature',
+              onClear: onClear,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GtSignaturePadController', () {
+    test('propagates strokes and maintains undo/redo history', () {
+      final controller = GtSignaturePadController();
+      addTearDown(controller.dispose);
+      var notifications = 0;
+      controller.addListener(() => notifications++);
+
+      controller.beginStroke(const Offset(10, 12));
+      controller.appendPoint(const Offset(18, 20));
+      controller.endStroke();
+
+      expect(controller.hasSignature, isTrue);
+      expect(controller.canUndo, isTrue);
+      expect(controller.canRedo, isFalse);
+      expect(controller.value.strokes.single.points, hasLength(2));
+
+      controller.undo();
+      expect(controller.hasSignature, isFalse);
+      expect(controller.canUndo, isFalse);
+      expect(controller.canRedo, isTrue);
+
+      controller.redo();
+      expect(controller.hasSignature, isTrue);
+      expect(controller.value.strokes.single.points.last, const Offset(18, 20));
+      expect(notifications, greaterThan(0));
+    });
+
+    test('starting a new stroke discards redo history', () {
+      final controller = GtSignaturePadController();
+      addTearDown(controller.dispose);
+
+      controller.beginStroke(const Offset(1, 1));
+      controller.endStroke();
+      controller.undo();
+      expect(controller.canRedo, isTrue);
+
+      controller.beginStroke(const Offset(2, 2));
+
+      expect(controller.canRedo, isFalse);
+      expect(controller.value.strokes.single.points.single, const Offset(2, 2));
+    });
+
+    test('clear removes visible strokes and history', () {
+      final controller = GtSignaturePadController();
+      addTearDown(controller.dispose);
+
+      controller.beginStroke(const Offset(1, 1));
+      controller.endStroke();
+      controller.undo();
+      controller.clear();
+
+      expect(controller.hasSignature, isFalse);
+      expect(controller.canUndo, isFalse);
+      expect(controller.canRedo, isFalse);
+      expect(controller.bytes, isNull);
+      expect(controller.base64, isNull);
+    });
+
+    test('setImage imports image bytes and exposes base64 and bytes', () async {
+      final controller = GtSignaturePadController();
+      addTearDown(controller.dispose);
+      final rawBytes = Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);
+
+      controller.setImage(rawBytes);
+
+      expect(controller.hasSignature, isTrue);
+      expect(controller.isImage, isTrue);
+      expect(controller.bytes, equals(rawBytes));
+      expect(controller.base64, equals(base64Encode(rawBytes)));
+
+      final freshBytes = await controller.toUint8List();
+      expect(freshBytes, equals(rawBytes));
+      final freshBase64 = await controller.toBase64();
+      expect(freshBase64, equals(base64Encode(rawBytes)));
+
+      controller.clear();
+      expect(controller.hasSignature, isFalse);
+      expect(controller.isImage, isFalse);
+      expect(controller.bytes, isNull);
+      expect(controller.base64, isNull);
+    });
+  });
+
+  group('GtSignaturePad', () {
+    testWidgets('renders the mapped empty state and accessible upload action', (
+      tester,
+    ) async {
+      final controller = GtSignaturePadController();
+      addTearDown(controller.dispose);
+      var uploadCalls = 0;
+      final semantics = tester.ensureSemantics();
+
+      try {
+        await tester.pumpWidget(
+          _SignaturePadTestApp(
+            controller: controller,
+            onSecondaryAction: () => uploadCalls++,
+          ),
+        );
+
+        expect(find.text('Tap to draw your signature'), findsOneWidget);
+        expect(
+          find.text('Use your finger or a stylus to sign here'),
+          findsOneWidget,
+        );
+        expect(find.byIcon(GtIcons.uploadFolder), findsOneWidget);
+        expect(find.bySemanticsLabel('Signature drawing area'), findsOneWidget);
+        expect(
+          find.bySemanticsLabel('Upload a signature instead'),
+          findsOneWidget,
+        );
+
+        await tester.tap(find.bySemanticsLabel('Upload a signature instead'));
+        await tester.pump();
+        expect(uploadCalls, 1);
+      } finally {
+        semantics.dispose();
+      }
+    });
+
+    testWidgets(
+      'draws and exposes a PNG through sync and async controller APIs',
+      (tester) async {
+        final controller = GtSignaturePadController(
+          screenShotService: _FakeScreenShotService(),
+        );
+        addTearDown(controller.dispose);
+        final changes = <Uint8List?>[];
+
+        await tester.pumpWidget(
+          _SignaturePadTestApp(
+            controller: controller,
+            onChanged: changes.add,
+            onSecondaryAction: () {},
+          ),
+        );
+
+        final canvas = find.descendant(
+          of: find.byType(GtSignaturePad),
+          matching: find.byType(CustomPaint),
+        );
+        final rect = tester.getRect(canvas);
+        final gesture = await tester.startGesture(
+          Offset(rect.left + 60, rect.center.dy),
+        );
+        await gesture.moveBy(const Offset(100, 24));
+        await gesture.up();
+        await tester.pump();
+        await tester.pump();
+
+        expect(controller.hasSignature, isTrue);
+        expect(find.text('Tap to draw your signature'), findsNothing);
+        expect(controller.bytes, isNotNull);
+        expect(controller.base64, isNotNull);
+        expect(base64Decode(controller.base64!), controller.bytes);
+        expect(
+          controller.bytes!.take(8),
+          orderedEquals(<int>[137, 80, 78, 71, 13, 10, 26, 10]),
+        );
+        expect(changes.whereType<Uint8List>(), isNotEmpty);
+
+        final freshBytes = await controller.toUint8List(pixelRatio: 1);
+        expect(freshBytes, isNotNull);
+      },
+    );
+
+    testWidgets('exposes built-in undo, redo, and clear actions', (
+      tester,
+    ) async {
+      final controller = GtSignaturePadController(
+        screenShotService: _FakeScreenShotService(),
+      );
+      addTearDown(controller.dispose);
+      var clearCalls = 0;
+
+      await tester.pumpWidget(
+        _SignaturePadTestApp(
+          controller: controller,
+          onSecondaryAction: () {},
+          onClear: () => clearCalls++,
+        ),
+      );
+
+      controller.beginStroke(const Offset(20, 20));
+      controller.appendPoint(const Offset(80, 60));
+      controller.endStroke();
+      await tester.pump();
+
+      expect(find.bySemanticsLabel('Undo signature stroke'), findsOneWidget);
+      expect(find.bySemanticsLabel('Redo signature stroke'), findsOneWidget);
+      expect(find.bySemanticsLabel('Clear signature'), findsOneWidget);
+
+      await tester.tap(find.bySemanticsLabel('Undo signature stroke'));
+      await tester.pump();
+      expect(controller.hasSignature, isFalse);
+      expect(controller.canRedo, isTrue);
+
+      await tester.tap(find.bySemanticsLabel('Redo signature stroke'));
+      await tester.pump();
+      expect(controller.hasSignature, isTrue);
+
+      await tester.tap(find.bySemanticsLabel('Clear signature'));
+      await tester.pump();
+      expect(controller.hasSignature, isFalse);
+      expect(controller.canRedo, isFalse);
+      expect(clearCalls, 1);
+    });
+
+    testWidgets('renders imported image preview and allows clearing it', (
+      tester,
+    ) async {
+      final controller = GtSignaturePadController();
+      addTearDown(controller.dispose);
+      final rawBytes = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      );
+
+      await tester.pumpWidget(
+        _SignaturePadTestApp(
+          controller: controller,
+          onSecondaryAction: () {},
+        ),
+      );
+
+      expect(find.text('Tap to draw your signature'), findsOneWidget);
+      expect(find.byType(GtImage), findsNothing);
+
+      controller.setImage(rawBytes);
+      await tester.pump();
+
+      expect(find.text('Tap to draw your signature'), findsNothing);
+      expect(find.byType(GtImage), findsOneWidget);
+      expect(find.bySemanticsLabel('Clear signature'), findsOneWidget);
+
+      await tester.tap(find.bySemanticsLabel('Clear signature'));
+      await tester.pump();
+
+      expect(controller.hasSignature, isFalse);
+      expect(find.byType(GtImage), findsNothing);
+      expect(find.text('Tap to draw your signature'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Description

- **Purpose:** Feature
- **Issue Link:** #180
- **Summary:** Implements the `GtSignaturePad` molecule and `GtSignaturePadController` to capture customer signatures via freehand drawing or native image picker import (`AppImagePlugin`). Also includes custom typography styling support for `GtTipCard` and `GtIllustratedStepTile`, action mode support on `GtSearchField`, and ping-pong `GtMarqueeScrollPhysics`.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

## 📸 Visuals (Screenshots or Screen Recordings)


https://github.com/user-attachments/assets/e8a166d4-449d-4af1-815c-847f3499d43a



## 🧪 How Has This Been Tested?

- [x] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated
- [x] Manual Testing (Describe steps below)
  - *Steps:*
    1. Opened `GtSignaturePad` in Widgetbook gallery.
    2. Drew freehand signatures and verified stroke capture and undo/redo/clear history.
    3. Tested native image import using `AppImagePlugin.pickImage()` and verified in-pad preview.
    4. Verified `bytes`, `base64`, `toUint8List()`, and `toBase64()` outputs.

## 📋 Checklist

- [x] `flutter analyze` passes locally.
- [x] `flutter test` passes (all tests green).
- [x] `dart format` applied.
- [x] No unused code.
- [x] Verified UI on small/large screens.
