### PR TITLE
feat: add GtTransferDetailScaffold and related components

### DIFF
--- a/gallery/lib/main.directories.g.dart
+++ b/gallery/lib/main.directories.g.dart
@@ -332,6 +332,8 @@ import 'package:gallery/templates/scaffolds/gt_receipt_scaffold_usecase.dart'
     as _gallery_templates_scaffolds_gt_receipt_scaffold_usecase;
 import 'package:gallery/templates/scaffolds/gt_summary_scaffold_usecase.dart'
     as _gallery_templates_scaffolds_gt_summary_scaffold_usecase;
+import 'package:gallery/templates/scaffolds/gt_transfer_detail_scaffold_usecase.dart'
+    as _gallery_templates_scaffolds_gt_transfer_detail_scaffold_usecase;
 import 'package:gallery/templates/screens/gt_debit_card_screen.dart'
     as _gallery_templates_screens_gt_debit_card_screen;
 import 'package:gallery/templates/screens/gt_debit_card_selection_screen.dart'
@@ -2115,6 +2117,17 @@ final directories = <_widgetbook.WidgetbookNode>[
                   ),
                 ],
               ),
+              _widgetbook.WidgetbookComponent(
+                name: 'GtTransferDetailBody',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'GtTransferDetailBody',
+                    builder:
+                        _gallery_templates_scaffolds_gt_transfer_detail_scaffold_usecase
+                            .playgroundGtTransferDetailBodyUseCase,
+                  ),
+                ],
+              ),
             ],
           ),
           _widgetbook.WidgetbookFolder(
@@ -2650,6 +2663,17 @@ final directories = <_widgetbook.WidgetbookNode>[
                     builder:
                         _gallery_templates_scaffolds_gt_summary_scaffold_usecase
                             .playgroundGtSummaryScaffoldGalleryUseCase,
+                  ),
+                ],
+              ),
+              _widgetbook.WidgetbookComponent(
+                name: 'GtTransferDetailScaffold',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'GtTransferDetailScaffold',
+                    builder:
+                        _gallery_templates_scaffolds_gt_transfer_detail_scaffold_usecase
+                            .playgroundGtTransferDetailScaffoldUseCase,
                   ),
                 ],
               ),

--- a/gallery/lib/molecules/text/gt_balance_text.dart
+++ b/gallery/lib/molecules/text/gt_balance_text.dart
@@ -23,6 +23,10 @@ Widget playgroundGtBalanceTextUseCase(BuildContext context) {
     label: 'Animate changes',
     initialValue: true,
   );
+  final showVisibilityIcon = context.knobs.boolean(
+    label: 'Show visibility icon',
+    initialValue: true,
+  );
 
   final codeSnippet =
       '''
@@ -31,6 +35,7 @@ GtBalanceText(
   hidden: $hidden,
   currencySymbol: "$currencySymbol",
   animateChanges: $animateChanges,
+  showVisibilityIcon: $showVisibilityIcon,
 )''';
 
   return _GtBalanceTextPlayground(
@@ -38,6 +43,7 @@ GtBalanceText(
     hidden: hidden,
     currencySymbol: currencySymbol,
     animateChanges: animateChanges,
+    showVisibilityIcon: showVisibilityIcon,
     codeSnippet: codeSnippet,
   );
 }
@@ -47,6 +53,7 @@ class _GtBalanceTextPlayground extends GtStatelessWidget {
   final bool hidden;
   final String currencySymbol;
   final bool animateChanges;
+  final bool showVisibilityIcon;
   final String codeSnippet;
 
   const _GtBalanceTextPlayground({
@@ -54,6 +61,7 @@ class _GtBalanceTextPlayground extends GtStatelessWidget {
     required this.hidden,
     required this.currencySymbol,
     required this.animateChanges,
+    required this.showVisibilityIcon,
     required this.codeSnippet,
   });
 
@@ -62,7 +70,7 @@ class _GtBalanceTextPlayground extends GtStatelessWidget {
     return GtWidgetDocPage(
       title: "GtBalanceText",
       description:
-          "Displays a formatted balance with optional masking and animated value changes.",
+          "Displays a formatted balance with optional masking and animated value changes. Turn off the visibility icon for amounts that are not meant to be toggled.",
       code: codeSnippet,
       child: Center(
         child: GtBalanceText(
@@ -71,6 +79,7 @@ class _GtBalanceTextPlayground extends GtStatelessWidget {
           currencySymbol: currencySymbol,
           textAlign: TextAlign.center,
           animateChanges: animateChanges,
+          showVisibilityIcon: showVisibilityIcon,
         ),
       ),
     );

--- a/gallery/lib/organisms/status/gt_status_tracker_usecase.dart
+++ b/gallery/lib/organisms/status/gt_status_tracker_usecase.dart
@@ -22,6 +22,13 @@ class _StatusTrackerGalleryViewState extends State<_StatusTrackerGalleryView>
     with GtBottomModalMixin {
   @override
   Widget build(BuildContext context) {
+    final variant = context.knobs.object.dropdown(
+      label: 'Variant',
+      options: GtStatusTrackerVariant.values,
+      initialOption: GtStatusTrackerVariant.standard,
+      labelBuilder: (v) => v.name,
+    );
+
     final step1State = context.knobs.object.dropdown(
       label: 'Step 1 State',
       options: GtStatusStepState.values,
@@ -88,6 +95,7 @@ class _StatusTrackerGalleryViewState extends State<_StatusTrackerGalleryView>
     final codeSnippet =
         '''
 GtStatusTracker(
+  variant: GtStatusTrackerVariant.${variant.name},
   steps: [
     GtStatusStepData(
       label: '$step1Label',
@@ -111,6 +119,8 @@ GtStatusTracker(
       description: '''
 <b>GtStatusTracker</b> renders a vertical multi-step status timeline with semantic state indicators, connecting lines, and automatic terminal checkmarks.
 
+The <b>compact</b> variant renders a denser timeline for detail cards: labels keep their casing, subtitles become trailing timestamps, and the track turns green once the final step is reached.
+
 It seamlessly integrates inside floating bottom sheets or standalone card views.''',
       code: codeSnippet,
       child: Column(
@@ -119,7 +129,7 @@ It seamlessly integrates inside floating bottom sheets or standalone card views.
         children: [
           GtCard(
             padding: context.insets.allDp(20.px),
-            child: GtStatusTracker(steps: currentSteps),
+            child: GtStatusTracker(steps: currentSteps, variant: variant),
           ),
           Wrap(
             spacing: context.spacingMd,
@@ -127,7 +137,7 @@ It seamlessly integrates inside floating bottom sheets or standalone card views.
             children: [
               _ScenarioChip(
                 label: 'Test Processing',
-                onTap: () => _openSheetWith(context, [
+                onTap: () => _openSheetWith(context, variant, [
                   const GtStatusStepData(
                     label: 'Processing',
                     state: GtStatusStepState.active,
@@ -145,7 +155,7 @@ It seamlessly integrates inside floating bottom sheets or standalone card views.
               ),
               _ScenarioChip(
                 label: 'Test Failed Sending',
-                onTap: () => _openSheetWith(context, [
+                onTap: () => _openSheetWith(context, variant, [
                   const GtStatusStepData(
                     label: 'Processed',
                     state: GtStatusStepState.success,
@@ -164,7 +174,7 @@ It seamlessly integrates inside floating bottom sheets or standalone card views.
               ),
               _ScenarioChip(
                 label: 'Test Reversed',
-                onTap: () => _openSheetWith(context, [
+                onTap: () => _openSheetWith(context, variant, [
                   const GtStatusStepData(
                     label: 'Processed',
                     state: GtStatusStepState.success,
@@ -184,7 +194,7 @@ It seamlessly integrates inside floating bottom sheets or standalone card views.
               ),
               _ScenarioChip(
                 label: 'Test Fully Delivered',
-                onTap: () => _openSheetWith(context, [
+                onTap: () => _openSheetWith(context, variant, [
                   const GtStatusStepData(
                     label: 'Processed',
                     state: GtStatusStepState.success,
@@ -209,12 +219,16 @@ It seamlessly integrates inside floating bottom sheets or standalone card views.
     );
   }
 
-  void _openSheetWith(BuildContext context, List<GtStatusStepData> steps) {
+  void _openSheetWith(
+    BuildContext context,
+    GtStatusTrackerVariant variant,
+    List<GtStatusStepData> steps,
+  ) {
     showBottomModalWithChild(
       context,
       child: Padding(
         padding: context.insets.defaultAllInsets,
-        child: GtStatusTracker(steps: steps),
+        child: GtStatusTracker(steps: steps, variant: variant),
       ),
       useRootNavigator: false,
     );

--- a/gallery/lib/templates/scaffolds/gt_transfer_detail_scaffold_usecase.dart
+++ b/gallery/lib/templates/scaffolds/gt_transfer_detail_scaffold_usecase.dart
@@ -1,0 +1,525 @@
+import 'package:flutter/material.dart';
+import 'package:gallery/lib.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'GtTransferDetailScaffold',
+  type: GtTransferDetailScaffold,
+)
+Widget playgroundGtTransferDetailScaffoldUseCase(BuildContext context) {
+  return const _TransferDetailScaffoldPreview();
+}
+
+@widgetbook.UseCase(name: 'GtTransferDetailBody', type: GtTransferDetailBody)
+Widget playgroundGtTransferDetailBodyUseCase(BuildContext context) {
+  return const _TransferDetailBodyInlinePreview();
+}
+
+const _timestamp = 'Sep 10, 2025 11:03 AM';
+
+List<GtStatusStepData> _getSteps(String scenario) {
+  return switch (scenario) {
+    'Sending' => const [
+      GtStatusStepData(
+        label: 'Processed',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Sending',
+        state: GtStatusStepState.active,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(label: 'Delivered', state: GtStatusStepState.pending),
+    ],
+    'Completing' => const [
+      GtStatusStepData(
+        label: 'Processed',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Sent',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Completing',
+        state: GtStatusStepState.active,
+        subtitle: _timestamp,
+      ),
+    ],
+    'Delivered' => const [
+      GtStatusStepData(
+        label: 'Processed',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Sent',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Delivered',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+    ],
+    'Failed' => const [
+      GtStatusStepData(
+        label: 'Processed',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Failed',
+        state: GtStatusStepState.failed,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(label: 'Delivered', state: GtStatusStepState.pending),
+    ],
+    'Failed, Then Reversed' => const [
+      GtStatusStepData(
+        label: 'Processed',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Failed',
+        state: GtStatusStepState.failed,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Reversed',
+        state: GtStatusStepState.reversed,
+        subtitle: _timestamp,
+      ),
+    ],
+    'Not Delivered' => const [
+      GtStatusStepData(
+        label: 'Processed',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Sent',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Not Delivered',
+        state: GtStatusStepState.failed,
+        subtitle: _timestamp,
+      ),
+    ],
+    'Reversed' => const [
+      GtStatusStepData(
+        label: 'Processed',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Sent',
+        state: GtStatusStepState.success,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(
+        label: 'Reversed',
+        state: GtStatusStepState.reversed,
+        subtitle: _timestamp,
+      ),
+    ],
+    _ => const [
+      GtStatusStepData(
+        label: 'Processing',
+        state: GtStatusStepState.active,
+        subtitle: _timestamp,
+      ),
+      GtStatusStepData(label: 'Sent', state: GtStatusStepState.pending),
+      GtStatusStepData(label: 'Delivered', state: GtStatusStepState.pending),
+    ],
+  };
+}
+
+List<GtReceiptAction> _getActions(String preset, BuildContext context) {
+  return switch (preset) {
+    'Send Again + View Receipt' => [
+      GtReceiptAction.primary(
+        label: "Send again",
+        icon: GtIcons.arrowNorthEast,
+        onTap: () {
+          GtToast.of(context).show("Send again tapped");
+        },
+      ),
+      GtReceiptAction(
+        label: "View receipt",
+        icon: GtIcons.fileContent,
+        style: GtReceiptActionStyle(variant: .secondary),
+        onTap: () {
+          GtToast.of(context).show("View receipt tapped");
+        },
+      ),
+    ],
+    'Single Action' => [
+      GtReceiptAction.primary(
+        label: "Send again",
+        icon: GtIcons.arrowNorthEast,
+        onTap: () {
+          GtToast.of(context).show("Send again tapped");
+        },
+      ),
+    ],
+    _ => const [],
+  };
+}
+
+List<GtTransferDetailSection> _getSections(
+  bool showFeeInfo,
+  BuildContext context,
+) {
+  return [
+    const GtTransferDetailSection(
+      tiles: [
+        GtReceiptTileData(
+          label: "Category",
+          value: "Transfer",
+          image: AppImageData(GtNetworkImages.transfer),
+        ),
+        GtReceiptTileData(
+          label: "Source Account",
+          value: "Savings · 1020293939",
+        ),
+        GtReceiptTileData(
+          label: "Message",
+          value: "House cleaning part payment",
+        ),
+      ],
+    ),
+    GtTransferDetailSection(
+      tiles: [
+        GtReceiptTileData(
+          label: "Fees (VAT Incl)",
+          value: "₦25",
+          onInfoTap: showFeeInfo
+              ? () => GtToast.of(context).show("Includes 7.5% VAT")
+              : null,
+        ),
+        GtReceiptTileData(
+          label: "Stamp duty",
+          value: "₦50",
+          onInfoTap: showFeeInfo
+              ? () => GtToast.of(
+                  context,
+                ).show("Charged on transfers of ₦10,000 and above")
+              : null,
+        ),
+      ],
+    ),
+    GtTransferDetailSection(
+      tiles: [
+        GtReceiptTileData(
+          label: "Reference",
+          value: "TRX24072983910527NGN",
+          onTap: () {
+            context.copyText("TRX24072983910527NGN");
+            GtToast.of(context).show("Reference copied to clipboard");
+          },
+        ),
+        GtReceiptTileData(
+          label: "Transaction ID",
+          value: "TRX24072983910527NGN",
+          onTap: () {
+            context.copyText("TRX24072983910527NGN");
+            GtToast.of(context).show("Transaction ID copied to clipboard");
+          },
+        ),
+        GtReceiptTileData(
+          label: "Session ID",
+          value: "999001240813123456789012345678",
+          onTap: () {
+            context.copyText("999001240813123456789012345678");
+            GtToast.of(context).show("Session ID copied to clipboard");
+          },
+        ),
+      ],
+    ),
+  ];
+}
+
+GtTransferDetailBody _buildConfiguredTransferDetailBody({
+  required BuildContext context,
+  ScrollController? controller,
+  required double amount,
+  required String recipientName,
+  required bool recipientHasTag,
+  required String scenario,
+  required String actionsPreset,
+  required bool showFeeInfo,
+}) {
+  final recipient = GtReceiptParticipant(
+    title: recipientName,
+    image: const AppImageData(GtNetworkImages.sampleAvatar1),
+    tag: recipientHasTag ? const AppImageData(GtVectors.logo) : null,
+    imageType: GtReceiptImageType.avatar,
+  );
+
+  return GtTransferDetailBody(
+    controller: controller,
+    amount: amount,
+    recipient: recipient,
+    actions: _getActions(actionsPreset, context),
+    steps: _getSteps(scenario),
+    sections: _getSections(showFeeInfo, context),
+  );
+}
+
+class _TransferDetailScaffoldPreview extends StatefulWidget {
+  const _TransferDetailScaffoldPreview();
+
+  @override
+  State<_TransferDetailScaffoldPreview> createState() =>
+      _TransferDetailScaffoldPreviewState();
+}
+
+class _TransferDetailScaffoldPreviewState
+    extends State<_TransferDetailScaffoldPreview>
+    with GtBottomSheetMixin {
+  void _openTransferDetailModal(
+    BuildContext context, {
+    required double amount,
+    required String recipientName,
+    required bool recipientHasTag,
+    required String scenario,
+    required String actionsPreset,
+    required bool showFeeInfo,
+    required bool showDownload,
+  }) {
+    showDraggableSheet(
+      context,
+      initialChildSize: .9,
+      maxChildSize: 1,
+      minChildSize: .5,
+      useRootNavigator: false,
+      builder: (controller) {
+        return GtTransferDetailScaffold(
+          onClose: () => GtRouter.forcePopView(),
+          onReportProblem: () {
+            GtToast.of(context).show("Report problem tapped");
+          },
+          onDownload: showDownload
+              ? () => GtToast.of(context).show("Download tapped")
+              : null,
+          body: _buildConfiguredTransferDetailBody(
+            context: context,
+            controller: controller,
+            amount: amount,
+            recipientName: recipientName,
+            recipientHasTag: recipientHasTag,
+            scenario: scenario,
+            actionsPreset: actionsPreset,
+            showFeeInfo: showFeeInfo,
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final amount = context.knobs.double.input(
+      label: 'Amount',
+      initialValue: 20000,
+    );
+
+    final recipientName = context.knobs.string(
+      label: 'Recipient: Name',
+      initialValue: 'Frances Nkatie',
+    );
+    final recipientHasTag = context.knobs.boolean(
+      label: 'Recipient: Has Tag',
+      initialValue: true,
+    );
+
+    final scenario = context.knobs.object.dropdown<String>(
+      label: 'Scenario',
+      options: [
+        'Processing',
+        'Sending',
+        'Completing',
+        'Delivered',
+        'Failed',
+        'Failed, Then Reversed',
+        'Not Delivered',
+        'Reversed',
+      ],
+      initialOption: 'Processing',
+    );
+
+    final actionsPreset = context.knobs.object.dropdown<String>(
+      label: 'Actions Preset',
+      options: ['Send Again + View Receipt', 'Single Action', 'No Actions'],
+      initialOption: 'Send Again + View Receipt',
+    );
+
+    final showFeeInfo = context.knobs.boolean(
+      label: 'Details: Show Fee Info',
+      initialValue: true,
+    );
+
+    final showDownload = context.knobs.boolean(
+      label: 'Show Download Action',
+      initialValue: false,
+    );
+
+    return GtWidgetDocPage(
+      title: 'GtTransferDetailScaffold',
+      description:
+          'A scaffold template for transfer detail screens. It shares the layout of GtReceiptScaffold and is designed to be presented modally via GtBottomSheetMixin. Use the Scenario knob to walk through every transfer outcome in the design.',
+      code:
+          '''
+showDraggableSheet(
+  context,
+  builder: (controller) {
+    return GtTransferDetailScaffold(
+      onClose: () => GtRouter.popView(),
+      onReportProblem: () => handleReportProblem(),
+      body: GtTransferDetailBody(
+        controller: controller,
+        amount: $amount,
+        recipient: const GtReceiptParticipant(
+          title: "$recipientName",
+          image: AppImageData(GtNetworkImages.sampleAvatar1),
+          imageType: GtReceiptImageType.avatar,
+        ),
+        steps: const [
+          GtStatusStepData(label: "Processed", state: GtStatusStepState.success),
+          GtStatusStepData(label: "Sending", state: GtStatusStepState.active),
+          GtStatusStepData(label: "Delivered", state: GtStatusStepState.pending),
+        ],
+        sections: const [
+          GtTransferDetailSection(
+            tiles: [GtReceiptTileData(label: "Stamp duty", value: "₦50")],
+          ),
+        ],
+      ),
+    );
+  },
+);''',
+      child: GtRaisedButton(
+        text: 'Present Transfer Detail Modal',
+        onPressed: () => _openTransferDetailModal(
+          context,
+          amount: amount,
+          recipientName: recipientName,
+          recipientHasTag: recipientHasTag,
+          scenario: scenario,
+          actionsPreset: actionsPreset,
+          showFeeInfo: showFeeInfo,
+          showDownload: showDownload,
+        ),
+      ),
+    );
+  }
+}
+
+class _TransferDetailBodyInlinePreview extends StatelessWidget {
+  const _TransferDetailBodyInlinePreview();
+
+  @override
+  Widget build(BuildContext context) {
+    final amount = context.knobs.double.input(
+      label: 'Amount',
+      initialValue: 20000,
+    );
+
+    final recipientName = context.knobs.string(
+      label: 'Recipient: Name',
+      initialValue: 'Frances Nkatie',
+    );
+    final recipientHasTag = context.knobs.boolean(
+      label: 'Recipient: Has Tag',
+      initialValue: true,
+    );
+
+    final scenario = context.knobs.object.dropdown<String>(
+      label: 'Scenario',
+      options: [
+        'Processing',
+        'Sending',
+        'Completing',
+        'Delivered',
+        'Failed',
+        'Failed, Then Reversed',
+        'Not Delivered',
+        'Reversed',
+      ],
+      initialOption: 'Processing',
+    );
+
+    final actionsPreset = context.knobs.object.dropdown<String>(
+      label: 'Actions Preset',
+      options: ['Send Again + View Receipt', 'Single Action', 'No Actions'],
+      initialOption: 'Send Again + View Receipt',
+    );
+
+    final showFeeInfo = context.knobs.boolean(
+      label: 'Details: Show Fee Info',
+      initialValue: true,
+    );
+
+    final transferDetailBody = _buildConfiguredTransferDetailBody(
+      context: context,
+      amount: amount,
+      recipientName: recipientName,
+      recipientHasTag: recipientHasTag,
+      scenario: scenario,
+      actionsPreset: actionsPreset,
+      showFeeInfo: showFeeInfo,
+    );
+
+    return GtWidgetDocPage(
+      title: 'GtTransferDetailBody',
+      description:
+          'Organism widget containing the recipient, amount, actions, a compact status tracker, and untitled cards of transfer details.',
+      code:
+          '''
+GtTransferDetailBody(
+  amount: $amount,
+  recipient: const GtReceiptParticipant(
+    title: "$recipientName",
+    image: AppImageData(GtNetworkImages.sampleAvatar1),
+    imageType: GtReceiptImageType.avatar,
+  ),
+  actions: [
+    GtReceiptAction.primary(
+      label: "Send again",
+      icon: GtIcons.arrowNorthEast,
+      onTap: () {},
+    ),
+  ],
+  steps: const [
+    GtStatusStepData(label: "Processed", state: GtStatusStepState.success),
+    GtStatusStepData(label: "Sending", state: GtStatusStepState.active),
+    GtStatusStepData(label: "Delivered", state: GtStatusStepState.pending),
+  ],
+  sections: [
+    GtTransferDetailSection(
+      tiles: [
+        GtReceiptTileData(
+          label: "Fees (VAT Incl)",
+          value: "₦25",
+          onInfoTap: ${showFeeInfo ? '() => explainFees()' : 'null'},
+        ),
+        const GtReceiptTileData(label: "Stamp duty", value: "₦50"),
+      ],
+    ),
+  ],
+)''',
+      child: GtSizedBox(height: 650, child: transferDetailBody),
+    );
+  }
+}

--- a/lib/common/assets/gt_icons.dart
+++ b/lib/common/assets/gt_icons.dart
@@ -655,8 +655,16 @@ class GtIcons {
   static const locationPin = IconData(0xf170, fontFamily: _f, fontPackage: _p);
   static const landBill = IconData(0xf171, fontFamily: _f, fontPackage: _p);
 
-  static const arrowNorthEastThin = IconData(0xf174, fontFamily: _f, fontPackage: _p);
-  static const walletAltFilled = IconData(0xf175, fontFamily: _f, fontPackage: _p);
+  static const arrowNorthEastThin = IconData(
+    0xf174,
+    fontFamily: _f,
+    fontPackage: _p,
+  );
+  static const walletAltFilled = IconData(
+    0xf175,
+    fontFamily: _f,
+    fontPackage: _p,
+  );
 
   /// A list containing all available [IconData] constants defined in [GtIcons].
   ///

--- a/lib/common/data/data.dart
+++ b/lib/common/data/data.dart
@@ -15,6 +15,7 @@ export 'gt_success_rate_data.dart';
 export 'gt_summary_data.dart';
 export 'gt_theme_setting.dart';
 export 'gt_transaction_category.dart';
+export 'gt_transfer_detail_data.dart';
 export 'gt_transfer_participant_data.dart';
 export 'gt_wheel_scroll_data.dart';
 export 'gt_widget_pair.dart';

--- a/lib/common/data/gt_receipt_data.dart
+++ b/lib/common/data/gt_receipt_data.dart
@@ -175,21 +175,50 @@ class GtReceiptMessageData extends AppEquatable {
   List<Object?> get props => [message, title, style];
 }
 
+/// Where [GtReceiptDetailTile] places a [GtReceiptTileData.image] relative to
+/// the value.
+enum GtReceiptTileImagePosition {
+  /// Before the value, as on the category row of [GtTransferDetailBody].
+  leading,
+
+  /// After the value. The default.
+  trailing,
+}
+
 class GtReceiptTileData extends AppEquatable {
   final String label;
   final String value;
   final AppImageData? image;
   final OnPressed? onTap;
 
+  /// Invoked when the info icon drawn after [label] is tapped.
+  ///
+  /// When non-null, [GtReceiptDetailTile] renders a [GtIcons.info] glyph beside
+  /// the label, typically to explain a fee or levy. When null, no icon is
+  /// drawn.
+  final OnPressed? onInfoTap;
+
+  /// Overrides the label announced for the info icon.
+  ///
+  /// Defaults to "More information about [label]".
+  final String? infoSemanticsLabel;
+
   const GtReceiptTileData({
     required this.label,
     required this.value,
     this.image,
     this.onTap,
+    this.onInfoTap,
+    this.infoSemanticsLabel,
   });
 
+  /// The label announced for the info icon.
+  String get displayInfoSemanticsLabel {
+    return infoSemanticsLabel ?? 'More information about $label';
+  }
+
   @override
-  List<Object?> get props => [label, value, image];
+  List<Object?> get props => [label, value, image, infoSemanticsLabel];
 }
 
 class GtReceiptDetails extends AppEquatable {

--- a/lib/common/data/gt_receipt_data.dart
+++ b/lib/common/data/gt_receipt_data.dart
@@ -2,22 +2,33 @@ import 'package:flutter/widgets.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
+/// The look of a [GtReceiptAction]'s button: a [GtButtonVariant] plus optional
+/// colour overrides.
 class GtReceiptActionStyle extends AppEquatable {
+  /// The button variant the action renders with.
   final GtButtonVariant variant;
+
+  /// Overrides the button's background colour.
   final Color? color;
+
+  /// Overrides the button's label colour.
   final Color? textColor;
 
+  /// Creates a [GtReceiptActionStyle].
   const GtReceiptActionStyle({
     required this.variant,
     this.color,
     this.textColor,
   });
 
+  /// A [GtButtonVariant.primary] style without colour overrides.
   const GtReceiptActionStyle.primary()
     : variant = .primary,
       color = null,
       textColor = null;
 
+  /// A [GtButtonVariant.neutral] style without colour overrides. The default
+  /// for [GtReceiptAction].
   const GtReceiptActionStyle.neutral()
     : variant = .neutral,
       color = null,
@@ -27,12 +38,23 @@ class GtReceiptActionStyle extends AppEquatable {
   List<Object?> get props => [variant, color, textColor];
 }
 
+/// An action button offered on a receipt or transfer detail screen, such as
+/// "Send again" or "View receipt". Rendered by [GtReceiptActionButton].
 class GtReceiptAction extends AppEquatable {
+  /// The button's label.
   final String label;
+
+  /// The icon drawn ahead of [label].
   final IconData icon;
+
+  /// Invoked when the button is tapped.
   final OnPressed onTap;
+
+  /// The button's variant and colour overrides. Defaults to
+  /// [GtReceiptActionStyle.neutral].
   final GtReceiptActionStyle style;
 
+  /// Creates a [GtReceiptAction].
   const GtReceiptAction({
     required this.label,
     required this.onTap,
@@ -40,18 +62,25 @@ class GtReceiptAction extends AppEquatable {
     this.style = const .neutral(),
   });
 
+  /// Creates a [GtReceiptAction] in the [GtReceiptActionStyle.primary] style.
   const GtReceiptAction.primary({
     required this.label,
     required this.onTap,
     required this.icon,
   }) : style = const .primary();
 
+  /// The button's background colour: the [style] override when set, the weak
+  /// background for a neutral action, and otherwise `null` so the variant's
+  /// own colour applies.
   Color? color(GtPalette palette) {
     if (style.color != null) return style.color;
     if (style.variant != .neutral) return null;
     return palette.bg.weak;
   }
 
+  /// The button's label colour: the [style] override when set, strong text for
+  /// a neutral action, and otherwise `null` so the variant's own colour
+  /// applies.
   Color? textColor(GtPalette palette) {
     if (style.textColor != null) return style.textColor;
     if (style.variant != .neutral) return null;
@@ -62,17 +91,43 @@ class GtReceiptAction extends AppEquatable {
   List<Object?> get props => [label, icon, style];
 }
 
-enum GtReceiptImageType { avatar, image }
+/// How a [GtReceiptParticipant]'s image is drawn.
+enum GtReceiptImageType {
+  /// A circular [GtAvatar] that falls back to initials and can carry a tag.
+  avatar,
 
+  /// A plain [GtImage], such as an account or wallet illustration.
+  image,
+}
+
+/// A party to a transaction: the sender or recipient on a [GtReceiptBody], or
+/// the recipient on a [GtTransferDetailBody].
 class GtReceiptParticipant extends AppEquatable {
+  /// The participant's name.
   final String title;
+
+  /// A secondary line beneath [title], such as a bank and account number.
   final String? subtitle;
+
+  /// The caption above [title] on a [GtReceiptBody]. Defaults to "From" or
+  /// "To" by position.
   final String? label;
+
+  /// The participant's avatar or image, drawn according to [imageType].
   final AppImageData image;
+
+  /// A small badge, such as a bank logo, drawn over the corner of an avatar.
+  /// Only used with [GtReceiptImageType.avatar].
   final AppImageData? tag;
+
+  /// How [image] is drawn. Defaults to [GtReceiptImageType.image].
   final GtReceiptImageType imageType;
+
+  /// The individual transactions behind this side of the receipt, listed in
+  /// an expandable breakdown on [GtReceiptBody].
   final List<GtReceiptTransaction> transactions;
 
+  /// Creates a [GtReceiptParticipant].
   const GtReceiptParticipant({
     required this.title,
 
@@ -96,15 +151,38 @@ class GtReceiptParticipant extends AppEquatable {
   ];
 }
 
-enum GtReceiptStatus { processing, ongoing, success, failed }
+/// The outcome shown on a receipt's status pill.
+enum GtReceiptStatus {
+  /// Still being processed. The pill shows a spinner.
+  processing,
 
+  /// In progress over time. The pill shows a repeat icon.
+  ongoing,
+
+  /// Completed successfully.
+  success,
+
+  /// Did not complete.
+  failed,
+}
+
+/// The status pill at the head of a [GtReceiptBody] or [GtConfirmationBody],
+/// rendered by [GtReceiptStatusPill].
 class GtReceiptStatusData extends AppEquatable {
+  /// The outcome, which selects the pill's variant, icon and default title.
   final GtReceiptStatus status;
+
+  /// Overrides the pill's text. See [displayTitle].
   final String? title;
+
+  /// Invoked when the pill is tapped. When null the pill is inert.
   final OnPressed? onPressed;
 
+  /// Creates a [GtReceiptStatusData].
   const GtReceiptStatusData({required this.status, this.title, this.onPressed});
 
+  /// The pill's text: [title] when supplied, otherwise the translated name of
+  /// [status].
   String get displayTitle {
     if (title.hasValue) return title!;
     final statusText = switch (status) {
@@ -116,6 +194,8 @@ class GtReceiptStatusData extends AppEquatable {
     return statusText.ctr();
   }
 
+  /// The pill's leading icon, or `null` while processing, when the pill shows
+  /// a spinner instead.
   IconData? get icon => switch (status) {
     .ongoing => GtIcons.repeat,
     .success => GtIcons.checkBox,
@@ -123,6 +203,7 @@ class GtReceiptStatusData extends AppEquatable {
     _ => null,
   };
 
+  /// The pill variant for [status].
   GtPillVariant get variant {
     return switch (status) {
       .processing => .away,
@@ -132,6 +213,8 @@ class GtReceiptStatusData extends AppEquatable {
     };
   }
 
+  /// The pill's border colour: the light away shade while processing,
+  /// otherwise the variant's own border.
   Color? borderColor(GtPalette palette) {
     return switch (variant) {
       .away => palette.away.light,
@@ -143,13 +226,24 @@ class GtReceiptStatusData extends AppEquatable {
   List<Object?> get props => [status, title];
 }
 
+/// One line of a [GtReceiptParticipant]'s transaction breakdown.
 class GtReceiptTransaction extends AppEquatable {
+  /// The transaction's name, such as "Airtime Top-up".
   final String title;
+
+  /// A secondary line beneath [title], such as the provider and number.
   final String subtitle;
+
+  /// The formatted amount, such as "₦ 5,000.00".
   final String value;
+
+  /// The avatar image, with the initials of [title] as its fallback.
   final AppImageData image;
+
+  /// A small badge drawn over the corner of the avatar.
   final AppImageData? tag;
 
+  /// Creates a [GtReceiptTransaction].
   const GtReceiptTransaction({
     required this.title,
     required this.subtitle,
@@ -162,13 +256,22 @@ class GtReceiptTransaction extends AppEquatable {
   List<Object?> get props => [title, subtitle, value, image, tag];
 }
 
+/// The sender's note, shown in its own card on a [GtReceiptBody].
 class GtReceiptMessageData extends AppEquatable {
+  /// The note itself.
   final String message;
+
+  /// Overrides the card's heading. See [displayTitle].
   final String? title;
+
+  /// Overrides the style of [message].
   final TextStyle? style;
 
+  /// Creates a [GtReceiptMessageData].
   const GtReceiptMessageData({required this.message, this.title, this.style});
 
+  /// The card's heading: [title] when supplied, otherwise the `message`
+  /// translation.
   String get displayTitle => title ?? 'message'.ctr();
 
   @override
@@ -185,10 +288,20 @@ enum GtReceiptTileImagePosition {
   trailing,
 }
 
+/// A label/value row on a receipt, confirmation or transfer detail card,
+/// rendered by [GtReceiptDetailTile].
 class GtReceiptTileData extends AppEquatable {
+  /// The row's label, such as "Reference".
   final String label;
+
+  /// The row's value, already formatted for display.
   final String value;
+
+  /// An image drawn beside [value], such as a category icon.
   final AppImageData? image;
+
+  /// Invoked when the row is tapped, typically to copy [value]. When null the
+  /// row is inert.
   final OnPressed? onTap;
 
   /// Invoked when the info icon drawn after [label] is tapped.
@@ -200,9 +313,10 @@ class GtReceiptTileData extends AppEquatable {
 
   /// Overrides the label announced for the info icon.
   ///
-  /// Defaults to "More information about [label]".
+  /// Defaults to the `moreInfoAbout` translation, passed [label] as `label`.
   final String? infoSemanticsLabel;
 
+  /// Creates a [GtReceiptTileData].
   const GtReceiptTileData({
     required this.label,
     required this.value,
@@ -214,18 +328,27 @@ class GtReceiptTileData extends AppEquatable {
 
   /// The label announced for the info icon.
   String get displayInfoSemanticsLabel {
-    return infoSemanticsLabel ?? 'More information about $label';
+    return infoSemanticsLabel ?? 'moreInfoAbout'.tr({'label': label});
   }
 
   @override
   List<Object?> get props => [label, value, image, infoSemanticsLabel];
 }
 
+/// The cards beneath the participants on a [GtReceiptBody]. Each card is
+/// omitted when it has nothing to show.
 class GtReceiptDetails extends AppEquatable {
+  /// The sender's note, shown in its own card.
   final GtReceiptMessageData? message;
+
+  /// The transaction category, shown in its own card with a larger image.
   final GtReceiptTileData? category;
+
+  /// The remaining rows, such as reference, session ID and fee, grouped in
+  /// one card.
   final List<GtReceiptTileData> tiles;
 
+  /// Creates a [GtReceiptDetails].
   const GtReceiptDetails({this.message, this.category, required this.tiles});
 
   @override

--- a/lib/common/data/gt_transfer_detail_data.dart
+++ b/lib/common/data/gt_transfer_detail_data.dart
@@ -1,0 +1,44 @@
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// An untitled group of label/value rows rendered as a single card within a
+/// [GtTransferDetailBody].
+///
+/// Each section maps to one card beneath the status tracker on a transfer
+/// detail screen — for example the category, source account and message; the
+/// fees and levies; or the reference and session identifiers.
+///
+/// Rows reuse [GtReceiptTileData]. Supplying an `image` draws it before the
+/// value, an `onTap` makes the row interactive (for example, tap-to-copy on a
+/// reference), and an `onInfoTap` adds an info icon beside the label.
+///
+/// Unlike [GtConfirmationSection], a section carries no heading.
+///
+/// Example usage:
+/// ```dart
+/// GtTransferDetailSection(
+///   tiles: [
+///     GtReceiptTileData(
+///       label: "Fees (VAT Incl)",
+///       value: "₦25",
+///       onInfoTap: () => explainFees(),
+///     ),
+///     const GtReceiptTileData(label: "Stamp duty", value: "₦50"),
+///   ],
+/// )
+/// ```
+class GtTransferDetailSection extends AppEquatable {
+  /// The label/value rows displayed in this section's card.
+  ///
+  /// Must contain at least one entry. This is asserted by
+  /// [GtTransferDetailBody] at build time rather than here, because
+  /// `List.length` is not const-evaluable and asserting on it would prevent
+  /// callers from declaring sections as `const`.
+  final List<GtReceiptTileData> tiles;
+
+  /// Creates a [GtTransferDetailSection].
+  const GtTransferDetailSection({required this.tiles});
+
+  @override
+  List<Object?> get props => [tiles];
+}

--- a/lib/common/styling/gt_text_styles.dart
+++ b/lib/common/styling/gt_text_styles.dart
@@ -14,6 +14,8 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 class GtTextStyles {
   /// The [BuildContext] used to access the current theme and scaling utilities.
   final BuildContext context;
+
+  /// The font families the styles are built from.
   final GtFonts fonts;
 
   /// Creates an instance of [GtTextStyles].
@@ -26,6 +28,11 @@ class GtTextStyles {
   // Handles the conversion from Figma's % tracking and pixel line-heights
   // into Flutter's native coordinate system.
   // ---------------------------------------------------------------------------
+
+  /// Builds a [TextStyle] from Figma's type tokens.
+  ///
+  /// [heightPx] is the line height in logical pixels and [widthPct] the
+  /// tracking as a percentage of [size].
   TextStyle buildStyle({
     required String family,
     required double size,
@@ -754,6 +761,7 @@ class GtTextStyles {
   // TITLES (title prefix) | Inter, Bold (700), High Tracking
   // ---------------------------------------------------------------------------
 
+  /// Generates the Title text style.
   TextStyle title({
     double? heightPx,
     Color? color,
@@ -778,6 +786,7 @@ class GtTextStyles {
     );
   }
 
+  /// Generates the Title 3 text style.
   TextStyle title3({
     double? heightPx,
     Color? color,
@@ -802,6 +811,7 @@ class GtTextStyles {
     );
   }
 
+  /// Generates the Medium Title (Title M) text style.
   TextStyle titleM({
     double? heightPx,
     Color? color,
@@ -955,6 +965,7 @@ class GtTextStyles {
   // SUBHEADINGS (subHead prefix) | Inter, Medium (500), High Tracking
   // ---------------------------------------------------------------------------
 
+  /// Generates the Extra Large Subheading (Subhead XL) text style.
   TextStyle subHeadXl({
     double? heightPx,
     Color? color,
@@ -1137,6 +1148,8 @@ class GtTextStyles {
   }
 
   /// Generates the Extra Small Subheading (Subhead XS) text style.
+  ///
+  /// Tracking defaults to 4%. Pass [widthPct] to override it.
   TextStyle subHeadXs({
     double? heightPx,
     Color? color,
@@ -1146,12 +1159,13 @@ class GtTextStyles {
     double? decorationThickness,
     TextDecorationStyle? decorationStyle,
     TextOverflow? overflow,
+    double? widthPct,
   }) {
     return buildStyle(
       family: fonts.body,
       size: 12,
       heightPx: heightPx ?? 16,
-      widthPct: 4.0,
+      widthPct: widthPct ?? 4.0,
       weight: weight ?? .w500,
       color: color,
       decoration: decoration,

--- a/lib/widgets/molecules/media/gt_avatar.dart
+++ b/lib/widgets/molecules/media/gt_avatar.dart
@@ -47,6 +47,9 @@ class GtAvatar extends GtStatelessWidget {
   /// Commonly used for status badges (e.g., online/offline dots) or small action icons.
   final Widget? tag;
 
+  /// The size of the square [tag] overlay. Defaults to 40% of [size].
+  final double? tagSize;
+
   /// Whether to draw a white border around the outer edge of the avatar.
   final bool showBorder;
 
@@ -77,6 +80,7 @@ class GtAvatar extends GtStatelessWidget {
     this.initials,
     this.isUserAvatar = false,
     this.tag,
+    this.tagSize,
     this.showBorder = false,
     this.forceGradiant = true,
     this.gradient,
@@ -89,6 +93,7 @@ class GtAvatar extends GtStatelessWidget {
   Widget build(BuildContext context) {
     final defaultSize = context.dp(36.px);
     final computedSize = size ?? defaultSize;
+    final computedTagSize = tagSize ?? computedSize * 0.4;
     final hasAvatar = avatar != null;
     final defaultGradient = forceGradiant
         ? context.gradients.avatarGradient
@@ -183,7 +188,7 @@ class GtAvatar extends GtStatelessWidget {
               if (tag != null)
                 FractionalTranslation(
                   translation: Offset(.9, .8),
-                  child: GtSquareConstrainedBox(computedSize * 0.4, child: tag),
+                  child: GtSquareConstrainedBox(computedTagSize, child: tag),
                 ),
             ],
           ),

--- a/lib/widgets/molecules/text/gt_balance_text.dart
+++ b/lib/widgets/molecules/text/gt_balance_text.dart
@@ -190,6 +190,7 @@ class GtBalanceText extends GtStatelessWidget {
     return semanticsLabel ?? 'Balance is $amtDisplay $currencySymbol';
   }
 
+  /// The trailing icon for the current [hidden] state.
   IconData get _viibilityIcon {
     return hidden ? hiddenIcon : visibleIcon;
   }
@@ -259,7 +260,11 @@ class GtBalanceText extends GtStatelessWidget {
 
     child = FittedBox(
       fit: .scaleDown,
-      child: Semantics(label: semanticLabel, child: child),
+      child: Semantics(
+        label: semanticLabel,
+        excludeSemantics: true,
+        child: child,
+      ),
     );
 
     if (showVisibilityIcon) {
@@ -272,17 +277,39 @@ class GtBalanceText extends GtStatelessWidget {
   }
 }
 
+/// A private widget that renders a [GtBalanceText] line with an
+/// odometer-style [GtAnimatedCounter] in place of the static amount, used
+/// while [GtBalanceText.animateChanges] is `true` and the balance is visible.
 class _GtAnimatedBalanceText extends GtStatelessWidget {
+  /// The raw balance the counter rolls to.
   final num amount;
+
+  /// The currency glyph drawn ahead of the counter.
   final String computedSymbol;
+
+  /// The resolved style of [computedSymbol].
   final TextStyle currencyStyle;
+
+  /// The resolved style of the counter.
   final TextStyle amountStyle;
+
+  /// Horizontal alignment of the whole line.
   final TextAlign textAlign;
+
+  /// Maximum lines for the whole line.
   final int? maxLines;
+
+  /// Duration of each roll.
   final Duration duration;
+
+  /// Curve of each roll.
   final Curve curve;
+
+  /// The visibility icon span, or `null` while
+  /// [GtBalanceText.showVisibilityIcon] is `false`.
   final WidgetSpan? trailing;
 
+  /// Creates a [_GtAnimatedBalanceText].
   const _GtAnimatedBalanceText({
     required this.amount,
     required this.computedSymbol,

--- a/lib/widgets/molecules/text/gt_balance_text.dart
+++ b/lib/widgets/molecules/text/gt_balance_text.dart
@@ -16,6 +16,10 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 /// fixed run of asterisks and any [animateChanges] motion is suppressed, so
 /// neither the width nor the movement of the line can leak the value.
 ///
+/// Set [showVisibilityIcon] to `false` for amounts that are not meant to be
+/// toggled, such as a transfer amount on a detail screen: the eye icon is
+/// dropped and the line becomes inert.
+///
 /// The line is wrapped in a [FittedBox] set to [BoxFit.scaleDown]: a balance
 /// too wide for its box shrinks rather than wrapping or ellipsizing, so give it
 /// a bounded width and expect large amounts to render smaller than the
@@ -109,8 +113,16 @@ class GtBalanceText extends GtStatelessWidget {
   /// comfortable at any type scale. Typically flips [hidden] in the caller.
   ///
   /// When `null` the line is inert — but the icon is still drawn, so pass a
-  /// callback wherever the eye is shown.
+  /// callback wherever the eye is shown, or set [showVisibilityIcon] to
+  /// `false`. Ignored while [showVisibilityIcon] is `false`.
   final OnPressed? onVisibilityIconTap;
+
+  /// Whether the trailing visibility icon is drawn.
+  ///
+  /// Defaults to `true`. When `false` the icon and its leading gap are
+  /// omitted, and the line is no longer a tap target, so
+  /// [onVisibilityIconTap] is ignored. [hidden] still masks the amount.
+  final bool showVisibilityIcon;
 
   /// The trailing icon shown while [hidden] is `true`.
   ///
@@ -151,6 +163,7 @@ class GtBalanceText extends GtStatelessWidget {
     this.currencyStyle,
     this.amountStyle,
     this.onVisibilityIconTap,
+    this.showVisibilityIcon = true,
     this.hiddenIcon = GtIcons.eyeOpen,
     this.visibleIcon = GtIcons.eyeClosed,
     this.iconSize,
@@ -195,17 +208,21 @@ class GtBalanceText extends GtStatelessWidget {
       );
     }
 
-    final trailing = WidgetSpan(
-      alignment: .middle,
-      child: GtAnimatedSwitcher(
-        child: GtIcon.withColor(
-          _viibilityIcon,
-          key: ValueKey(hidden),
-          size: iconSize ?? context.dp(16.px),
-          color: iconColor ?? context.palette.icon.sub,
+    WidgetSpan? trailing;
+
+    if (showVisibilityIcon) {
+      trailing = WidgetSpan(
+        alignment: .middle,
+        child: GtAnimatedSwitcher(
+          child: GtIcon.withColor(
+            _viibilityIcon,
+            key: ValueKey(hidden),
+            size: iconSize ?? context.dp(16.px),
+            color: iconColor ?? context.palette.icon.sub,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     Widget child = Text.rich(
       TextSpan(
@@ -215,8 +232,10 @@ class GtBalanceText extends GtStatelessWidget {
             child: GtText('$currencySymbol ', style: symbolStyle),
           ),
           TextSpan(text: amtDisplay),
-          const WidgetSpan(child: GtGap.hSm()),
-          trailing,
+          if (trailing case WidgetSpan widget) ...[
+            const WidgetSpan(child: GtGap.hSm()),
+            widget,
+          ],
         ],
       ),
       textAlign: textAlign,
@@ -238,15 +257,18 @@ class GtBalanceText extends GtStatelessWidget {
       );
     }
 
-    return GtTapTarget(
-      child: GtInkWell(
-        onTap: onVisibilityIconTap,
-        child: FittedBox(
-          fit: .scaleDown,
-          child: Semantics(label: semanticLabel, child: child),
-        ),
-      ),
+    child = FittedBox(
+      fit: .scaleDown,
+      child: Semantics(label: semanticLabel, child: child),
     );
+
+    if (showVisibilityIcon) {
+      child = GtTapTarget(
+        child: GtInkWell(onTap: onVisibilityIconTap, child: child),
+      );
+    }
+
+    return child;
   }
 }
 
@@ -259,7 +281,7 @@ class _GtAnimatedBalanceText extends GtStatelessWidget {
   final int? maxLines;
   final Duration duration;
   final Curve curve;
-  final InlineSpan trailing;
+  final WidgetSpan? trailing;
 
   const _GtAnimatedBalanceText({
     required this.amount,
@@ -294,8 +316,10 @@ class _GtAnimatedBalanceText extends GtStatelessWidget {
               curve: curve,
             ),
           ),
-          const WidgetSpan(child: GtGap.hSm()),
-          trailing,
+          if (trailing case WidgetSpan widget) ...[
+            const WidgetSpan(child: GtGap.hSm()),
+            widget,
+          ],
         ],
       ),
       textAlign: textAlign,

--- a/lib/widgets/molecules/tiles/gt_info_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_info_tiles.dart
@@ -439,6 +439,13 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
   /// An optional widget displayed immediately after the [value].
   final Widget? valueSuffix;
 
+  /// An optional widget displayed immediately after the [label], such as an
+  /// info icon.
+  ///
+  /// The label shrinks to make room for it, so a long label is ellipsised
+  /// rather than pushing the suffix out of view.
+  final Widget? labelSuffix;
+
   ///Maximum number of lines for the label.
   final int labelMaxLines;
 
@@ -463,6 +470,7 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
     required this.value,
     this.valuePrefix,
     this.valueSuffix,
+    this.labelSuffix,
     this.labelMaxLines = 1,
     this.valueMaxLines = 2,
     this.highlightValue = true,
@@ -486,18 +494,27 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
       valueStyle = valueStyle.copyWith(color: palette.soft);
     }
 
+    Widget labelChild = GtText(
+      label,
+      style: labelStyle,
+      maxLines: labelMaxLines,
+      overflow: .ellipsis,
+    );
+
+    if (labelSuffix != null) {
+      labelChild = Row(
+        spacing: context.spacingSm,
+        children: [
+          Flexible(child: labelChild),
+          labelSuffix!,
+        ],
+      );
+    }
+
     return Row(
       spacing: context.spacingMd,
       children: [
-        Expanded(
-          flex: 4,
-          child: GtText(
-            label,
-            style: labelStyle,
-            maxLines: labelMaxLines,
-            overflow: .ellipsis,
-          ),
-        ),
+        Expanded(flex: 4, child: labelChild),
         Expanded(
           flex: 5,
           child: Row(

--- a/lib/widgets/molecules/tiles/gt_info_tiles.dart
+++ b/lib/widgets/molecules/tiles/gt_info_tiles.dart
@@ -446,6 +446,11 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
   /// rather than pushing the suffix out of view.
   final Widget? labelSuffix;
 
+  /// The gap between the [value] and its [valuePrefix] or [valueSuffix].
+  ///
+  /// Defaults to 8dp.
+  final double? valueSpacing;
+
   ///Maximum number of lines for the label.
   final int labelMaxLines;
 
@@ -471,6 +476,7 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
     this.valuePrefix,
     this.valueSuffix,
     this.labelSuffix,
+    this.valueSpacing,
     this.labelMaxLines = 1,
     this.valueMaxLines = 2,
     this.highlightValue = true,
@@ -519,7 +525,7 @@ class GtDoubleColumnListTile extends GtStatelessWidget {
           flex: 5,
           child: Row(
             mainAxisAlignment: .end,
-            spacing: context.spacingBase,
+            spacing: valueSpacing ?? context.spacingBase,
             children: [
               ?valuePrefix,
               Flexible(

--- a/lib/widgets/organisms/app_bars/gt_home_app_bar.dart
+++ b/lib/widgets/organisms/app_bars/gt_home_app_bar.dart
@@ -61,7 +61,7 @@ class GtHomeAppBar extends GtStatelessWidget implements PreferredSizeWidget {
     final toolbarHeight = MediaQuery.paddingOf(context).top;
     final btnColor = context.palette.primary.alpha16;
     final avatarColor = context.palette.primary.dark;
-    final iconColor = switch(context.isInDarkMode) {
+    final iconColor = switch (context.isInDarkMode) {
       true => context.palette.primary.base,
       _ => context.palette.primary.darker,
     };
@@ -140,8 +140,8 @@ class GtHomeAppBar extends GtStatelessWidget implements PreferredSizeWidget {
                 textCase: .title,
                 style: context.textStyles.subHeadS(
                   color: iconColor,
-                  weight: .w600
-                )
+                  weight: .w600,
+                ),
               ),
           ],
         ),

--- a/lib/widgets/organisms/headers/gt_section_header.dart
+++ b/lib/widgets/organisms/headers/gt_section_header.dart
@@ -129,7 +129,9 @@ class GtTransactionGroupHeader extends GtStatelessWidget {
       crossAxisAlignment: .center,
       spacing: context.spacingMd,
       children: [
-        Expanded(child: GtText(title.capitalise(), style: style ?? defaultStyle)),
+        Expanded(
+          child: GtText(title.capitalise(), style: style ?? defaultStyle),
+        ),
         ?trailing,
       ],
     );

--- a/lib/widgets/organisms/receipts/gt_receipt_body.dart
+++ b/lib/widgets/organisms/receipts/gt_receipt_body.dart
@@ -2,17 +2,42 @@ import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
+/// The scrollable content of a transaction receipt.
+///
+/// Presents, from top to bottom: the [status] pill, the [amount], an optional
+/// horizontally scrolling row of [actions], a card with the [from] and [to]
+/// participants, the [details] cards, and an optional [footer]. It reserves
+/// trailing space for the floating bottom bar of [GtReceiptScaffold].
 class GtReceiptBody extends GtStatelessWidget {
+  /// An optional controller for the underlying scroll view, typically the one
+  /// handed to you by a draggable sheet builder.
   final ScrollController? controller;
+
+  /// Optional scroll physics. Defaults to [ClampingScrollPhysics].
   final ScrollPhysics? physics;
+
+  /// The actions rendered beneath the amount. When empty, no row is rendered.
   final List<GtReceiptAction> actions;
+
+  /// The party the money came from.
   final GtReceiptParticipant from;
+
+  /// The party the money went to.
   final GtReceiptParticipant to;
+
+  /// The status pill at the head of the receipt.
   final GtReceiptStatusData status;
+
+  /// The formatted amount, such as "250,000.00".
   final String amount;
+
+  /// The message, category and detail rows beneath the participants.
   final GtReceiptDetails details;
+
+  /// An optional widget rendered beneath the details.
   final Widget? footer;
 
+  /// Creates a [GtReceiptBody].
   const GtReceiptBody({
     super.key,
     this.controller,
@@ -144,9 +169,13 @@ class GtReceiptBody extends GtStatelessWidget {
   }
 }
 
+/// A private widget that renders a [GtReceiptMessageData] as a heading over
+/// the note.
 class _ReceiptMessage extends GtStatelessWidget {
+  /// The note and its heading.
   final GtReceiptMessageData message;
 
+  /// Creates a [_ReceiptMessage].
   const _ReceiptMessage(this.message, {super.key});
 
   @override
@@ -165,9 +194,13 @@ class _ReceiptMessage extends GtStatelessWidget {
   }
 }
 
+/// A private widget that renders the category row, with its image drawn at
+/// 36dp after the value.
 class _ReceiptCategory extends GtStatelessWidget {
+  /// The category's label, value, image and tap handler.
   final GtReceiptTileData data;
 
+  /// Creates a [_ReceiptCategory].
   const _ReceiptCategory(this.data, {super.key});
 
   @override
@@ -200,10 +233,17 @@ class _ReceiptCategory extends GtStatelessWidget {
   }
 }
 
+/// A private widget that renders a [GtReceiptParticipant], expanding into its
+/// transaction breakdown when it has one.
 class _ReceiptParticipant extends GtStatelessWidget {
+  /// The participant to render.
   final GtReceiptParticipant data;
+
+  /// Whether this is the sender, which selects the default "From" caption
+  /// over "To".
   final bool isFrom;
 
+  /// Creates a [_ReceiptParticipant].
   const _ReceiptParticipant(this.data, {super.key, this.isFrom = true});
 
   @override
@@ -266,9 +306,13 @@ class _ReceiptParticipant extends GtStatelessWidget {
   }
 }
 
+/// A private widget that renders one [GtReceiptTransaction] in a
+/// participant's breakdown.
 class _ReceiptTransactionItem extends GtStatelessWidget {
+  /// The transaction to render.
   final GtReceiptTransaction transaction;
 
+  /// Creates a [_ReceiptTransactionItem].
   const _ReceiptTransactionItem(this.transaction, {super.key});
 
   @override

--- a/lib/widgets/organisms/receipts/gt_receipt_body.dart
+++ b/lib/widgets/organisms/receipts/gt_receipt_body.dart
@@ -66,7 +66,7 @@ class GtReceiptBody extends GtStatelessWidget {
               spacing: context.spacingBase,
               children: [
                 for (final (index, action) in actions.indexed)
-                  _ReceiptAction(
+                  GtReceiptActionButton(
                     action: action,
                     key: Key('receipt-action-$index'),
                   ),
@@ -197,27 +197,6 @@ class _ReceiptCategory extends GtStatelessWidget {
       );
     }
     return child;
-  }
-}
-
-class _ReceiptAction extends GtStatelessWidget {
-  final GtReceiptAction action;
-
-  const _ReceiptAction({super.key, required this.action});
-
-  @override
-  Widget build(BuildContext context) {
-    return GtRaisedButton(
-      onPressed: action.onTap,
-      text: action.label,
-      variant: action.style.variant,
-      alignment: .center,
-      size: .small,
-      leading: action.icon,
-      contentPadding: context.insets.symmetricDp(horizontal: 12.px),
-      textColor: action.textColor(context.palette),
-      color: action.color(context.palette),
-    );
   }
 }
 

--- a/lib/widgets/organisms/receipts/gt_receipt_parts.dart
+++ b/lib/widgets/organisms/receipts/gt_receipt_parts.dart
@@ -164,7 +164,12 @@ class GtReceiptActionButton extends GtStatelessWidget {
   /// The label, icon, style and tap handler for this button.
   final GtReceiptAction action;
 
-  /// The alignment of the button
+  /// How the button is positioned within the space it is given, forwarded to
+  /// [GtRaisedButton.alignment].
+  ///
+  /// Defaults to [Alignment.center], which wraps the button in an [Align] that
+  /// fills the available width. Pass `null` to size the button to its content,
+  /// as [GtTransferDetailBody] does inside its [Wrap].
   final AlignmentGeometry? alignment;
 
   /// Creates a [GtReceiptActionButton].

--- a/lib/widgets/organisms/receipts/gt_receipt_parts.dart
+++ b/lib/widgets/organisms/receipts/gt_receipt_parts.dart
@@ -29,12 +29,18 @@ class GtReceiptDetailTile extends GtStatelessWidget {
   /// Defaults to [GtReceiptTileImagePosition.trailing].
   final GtReceiptTileImagePosition imagePosition;
 
+  /// The gap between the value and the tile's image.
+  ///
+  /// Defaults to the spacing of [GtDoubleColumnListTile].
+  final double? valueSpacing;
+
   /// Creates a [GtReceiptDetailTile].
   const GtReceiptDetailTile(
     this.tile, {
     super.key,
     this.highlightValue = false,
     this.imagePosition = .trailing,
+    this.valueSpacing,
   });
 
   @override
@@ -75,6 +81,7 @@ class GtReceiptDetailTile extends GtStatelessWidget {
       valueSuffix: imagePosition == .trailing ? image : null,
       labelSuffix: info,
       highlightValue: highlightValue,
+      valueSpacing: valueSpacing,
     );
 
     if (tile.onTap != null) {

--- a/lib/widgets/organisms/receipts/gt_receipt_parts.dart
+++ b/lib/widgets/organisms/receipts/gt_receipt_parts.dart
@@ -2,26 +2,45 @@ import 'package:flutter/material.dart';
 import 'package:gt_mobile_foundation/foundation.dart';
 import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 
-/// A single label/value row within a receipt or confirmation card.
+/// A single label/value row within a receipt, confirmation or transfer detail
+/// card.
 ///
-/// Renders [GtReceiptTileData] as a [GtDoubleColumnListTile] with the label
-/// emphasised over the value. When the tile carries an `image`, it is rendered
-/// as a 20dp suffix after the value; when it carries an `onTap`, the row is
-/// wrapped in a [GtInkWell] (commonly used for tap-to-copy on references and
-/// session IDs).
+/// Renders [GtReceiptTileData] as a [GtDoubleColumnListTile]. When the tile
+/// carries an `image`, it is rendered as a 20dp image beside the value, placed
+/// by [imagePosition]; when it carries an `onTap`, the row is wrapped in a
+/// [GtInkWell] (commonly used for tap-to-copy on references and session IDs);
+/// and when it carries an `onInfoTap`, a tappable [GtIcons.info] glyph follows
+/// the label.
 ///
-/// Shared by [GtReceiptBody] and [GtConfirmationBody].
+/// Shared by [GtReceiptBody], [GtConfirmationBody] and [GtTransferDetailBody].
 class GtReceiptDetailTile extends GtStatelessWidget {
-  /// The label, value, optional image and optional tap handler for this row.
+  /// The label, value, optional image and optional tap handlers for this row.
   final GtReceiptTileData tile;
 
+  /// Whether the value is emphasised over the label.
+  ///
+  /// Defaults to `false`: a strong label over a soft value, as on
+  /// [GtReceiptBody] and [GtConfirmationBody]. [GtTransferDetailBody] passes
+  /// `true` for a soft label over a strong value.
+  final bool highlightValue;
+
+  /// Where the tile's image sits relative to the value.
+  ///
+  /// Defaults to [GtReceiptTileImagePosition.trailing].
+  final GtReceiptTileImagePosition imagePosition;
+
   /// Creates a [GtReceiptDetailTile].
-  const GtReceiptDetailTile(this.tile, {super.key});
+  const GtReceiptDetailTile(
+    this.tile, {
+    super.key,
+    this.highlightValue = false,
+    this.imagePosition = .trailing,
+  });
 
   @override
   Widget build(BuildContext context) {
     final imageSize = context.dp(20.px);
-    final suffix = tile.image != null
+    final image = tile.image != null
         ? GtImage(
             image: tile.image!,
             width: imageSize,
@@ -30,11 +49,32 @@ class GtReceiptDetailTile extends GtStatelessWidget {
           )
         : null;
 
+    Widget? info;
+    if (tile.onInfoTap != null) {
+      info = GtTapTarget(
+        child: GtInkWell(
+          key: const Key('receipt-tile-info'),
+          role: .button,
+          onTap: tile.onInfoTap,
+          semanticsLabel: tile.displayInfoSemanticsLabel,
+          excludeDescendantSemantics: true,
+          borderRadius: context.borderRadiusSm,
+          child: GtIcon.withColor(
+            GtIcons.info,
+            color: context.palette.icon.soft,
+            size: context.dp(16.px),
+          ),
+        ),
+      );
+    }
+
     final child = GtDoubleColumnListTile(
       tile.label,
       value: tile.value,
-      valueSuffix: suffix,
-      highlightValue: false,
+      valuePrefix: imagePosition == .leading ? image : null,
+      valueSuffix: imagePosition == .trailing ? image : null,
+      labelSuffix: info,
+      highlightValue: highlightValue,
     );
 
     if (tile.onTap != null) {
@@ -110,5 +150,42 @@ class GtReceiptStatusPill extends GtStatelessWidget {
     }
 
     return pill;
+  }
+}
+
+/// A compact action button displayed beneath the amount on a receipt or
+/// transfer detail screen.
+///
+/// Renders [GtReceiptAction] as a small [GtRaisedButton] with a leading icon,
+/// taking its variant and any custom colours from the action's style.
+///
+/// Shared by [GtReceiptBody] and [GtTransferDetailBody].
+class GtReceiptActionButton extends GtStatelessWidget {
+  /// The label, icon, style and tap handler for this button.
+  final GtReceiptAction action;
+
+  /// The alignment of the button
+  final AlignmentGeometry? alignment;
+
+  /// Creates a [GtReceiptActionButton].
+  const GtReceiptActionButton({
+    super.key,
+    required this.action,
+    this.alignment = .center,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GtRaisedButton(
+      onPressed: action.onTap,
+      text: action.label,
+      variant: action.style.variant,
+      alignment: alignment,
+      size: .small,
+      leading: action.icon,
+      contentPadding: context.insets.symmetricDp(horizontal: 12.px),
+      textColor: action.textColor(context.palette),
+      color: action.color(context.palette),
+    );
   }
 }

--- a/lib/widgets/organisms/receipts/gt_transfer_detail_body.dart
+++ b/lib/widgets/organisms/receipts/gt_transfer_detail_body.dart
@@ -195,6 +195,7 @@ class GtTransferDetailBody extends GtStatelessWidget {
                     tile,
                     highlightValue: true,
                     imagePosition: .leading,
+                    valueSpacing: context.spacingXs,
                     key: Key('transfer-detail-section-$index-tile-$position'),
                   ),
               ],
@@ -260,6 +261,7 @@ class _TransferDetailHeader extends GtStatelessWidget {
         size: imageSize,
         initials: recipient.title.initials,
         tag: tag,
+        tagSize: context.dp(28.px),
         showBorder: true,
       ),
     };

--- a/lib/widgets/organisms/receipts/gt_transfer_detail_body.dart
+++ b/lib/widgets/organisms/receipts/gt_transfer_detail_body.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// The scrollable content of a transfer detail screen.
+///
+/// Presents, from top to bottom:
+/// - The [recipient]'s avatar, with an optional bank tag, above their name.
+/// - The transfer [amount], rendered by a [GtBalanceText] without its
+///   visibility icon: prefixed by [currency] and scaled down to fit on a
+///   single line.
+/// - An optional, centred row of [actions] such as "Send again" and
+///   "View receipt".
+/// - A card holding a [GtStatusTracker] in its
+///   [GtStatusTrackerVariant.compact] layout, built from [steps].
+/// - One card per [GtTransferDetailSection], filled with
+///   [GtReceiptDetailTile] rows. Row images sit before the value, and rows
+///   carrying an `onInfoTap` show an info icon beside their label.
+/// - An optional [footer].
+///
+/// Of the [recipient], only the `title`, `image`, `tag` and `imageType` are
+/// rendered.
+///
+/// Like [GtReceiptBody], it reserves trailing space for the floating bottom
+/// bar of [GtTransferDetailScaffold]. The [amount] is formatted by
+/// [GtBalanceText]; timestamps and row values are never formatted here, so
+/// callers pass presentation-ready strings for those.
+///
+/// Example usage:
+/// ```dart
+/// GtTransferDetailBody(
+///   amount: 20000,
+///   recipient: const GtReceiptParticipant(
+///     title: "Frances Nkatie",
+///     image: AppImageData(avatarUrl),
+///     imageType: GtReceiptImageType.avatar,
+///     tag: AppImageData(bankLogoUrl),
+///   ),
+///   actions: [
+///     GtReceiptAction.primary(
+///       label: "Send again",
+///       icon: GtIcons.arrowNorthEast,
+///       onTap: () => sendAgain(),
+///     ),
+///   ],
+///   steps: const [
+///     GtStatusStepData(
+///       label: "Processed",
+///       state: GtStatusStepState.success,
+///       subtitle: "Sep 10, 2025 11:03 AM",
+///     ),
+///     GtStatusStepData(label: "Sent", state: GtStatusStepState.active),
+///     GtStatusStepData(label: "Delivered", state: GtStatusStepState.pending),
+///   ],
+///   sections: [
+///     GtTransferDetailSection(
+///       tiles: [
+///         GtReceiptTileData(
+///           label: "Fees (VAT Incl)",
+///           value: "₦25",
+///           onInfoTap: () => explainFees(),
+///         ),
+///       ],
+///     ),
+///   ],
+/// )
+/// ```
+class GtTransferDetailBody extends GtStatelessWidget {
+  /// An optional controller for the underlying scroll view.
+  ///
+  /// Supply the controller handed to you by a draggable sheet builder so the
+  /// content and the sheet scroll as one.
+  final ScrollController? controller;
+
+  /// Optional scroll physics. Defaults to [ClampingScrollPhysics].
+  final ScrollPhysics? physics;
+
+  /// The person or business the transfer was sent to.
+  final GtReceiptParticipant recipient;
+
+  /// The raw transfer amount, for example `20000`.
+  ///
+  /// Formatted with comma separators and two decimal places by
+  /// [GtBalanceText], so `20000` renders as `20,000.00`.
+  final num amount;
+
+  /// The currency glyph drawn ahead of [amount] in a smaller type.
+  ///
+  /// Defaults to [AppStrings.naira] (`₦`).
+  final String currency;
+
+  /// Overrides the label announced for [amount].
+  ///
+  /// Defaults to `'Transfer amount is <amount> <currency>'`.
+  final String? amountSemanticsLabel;
+
+  /// The actions rendered as a centred row beneath the amount.
+  ///
+  /// When empty, no row is rendered.
+  final List<GtReceiptAction> actions;
+
+  /// The ordered progress of the transfer, rendered as a compact
+  /// [GtStatusTracker].
+  ///
+  /// When empty, the status card is omitted.
+  final List<GtStatusStepData> steps;
+
+  /// The groups of label/value rows rendered as cards beneath the status card.
+  ///
+  /// Every section must contain at least one tile. This is asserted at build
+  /// time rather than in the constructor so callers can declare this widget
+  /// and its sections as `const`.
+  final List<GtTransferDetailSection> sections;
+
+  /// An optional widget rendered beneath the final section.
+  final Widget? footer;
+
+  /// Creates a [GtTransferDetailBody].
+  ///
+  /// The [recipient], [amount] and [steps] parameters are required.
+  const GtTransferDetailBody({
+    super.key,
+    this.controller,
+    this.physics,
+    this.currency = AppStrings.naira,
+    this.amountSemanticsLabel,
+    this.actions = const [],
+    this.sections = const [],
+    this.footer,
+    required this.recipient,
+    required this.amount,
+    required this.steps,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    assert(
+      sections.every((section) => section.tiles.hasValue),
+      'Every GtTransferDetailSection requires at least one tile',
+    );
+
+    final cardRadius = context.borderRadiusXl;
+
+    return ListView(
+      physics: physics ?? const ClampingScrollPhysics(),
+      controller: controller,
+      padding: context.insets.allDp(16.px),
+      children: [
+        _TransferDetailHeader(
+          recipient: recipient,
+          amount: amount,
+          currency: currency,
+          amountSemanticsLabel: amountSemanticsLabel,
+        ),
+        if (actions.hasValue) ...[
+          const GtGap.yLg(),
+          Wrap(
+            alignment: .center,
+            spacing: context.spacingBase,
+            runSpacing: context.spacingBase,
+            runAlignment: .center,
+            children: [
+              for (final (index, action) in actions.indexed)
+                GtReceiptActionButton(
+                  action: action,
+                  alignment: null,
+                  key: Key('transfer-detail-action-$index'),
+                ),
+            ],
+          ),
+        ],
+        const GtGap.yLg(),
+        if (steps.hasValue) ...[
+          GtCard(
+            key: const Key('transfer-detail-status'),
+            padding: context.insets.allDp(16.px),
+            borderRadius: cardRadius,
+            child: GtStatusTracker(steps: steps, variant: .compact),
+          ),
+          const GtGap.yLg(),
+        ],
+        for (final (index, section) in sections.indexed) ...[
+          GtCard(
+            key: Key('transfer-detail-section-$index'),
+            padding: context.insets.allDp(12.px),
+            borderRadius: cardRadius,
+            child: Column(
+              spacing: context.spacingXl,
+              mainAxisSize: .min,
+              crossAxisAlignment: .stretch,
+              children: [
+                for (final (position, tile) in section.tiles.indexed)
+                  GtReceiptDetailTile(
+                    tile,
+                    highlightValue: true,
+                    imagePosition: .leading,
+                    key: Key('transfer-detail-section-$index-tile-$position'),
+                  ),
+              ],
+            ),
+          ),
+          const GtGap.yLg(),
+        ],
+        ?footer,
+        const GtGap.ySection4xl(),
+      ],
+    );
+  }
+}
+
+/// The recipient's avatar and name above the transfer amount.
+class _TransferDetailHeader extends GtStatelessWidget {
+  final GtReceiptParticipant recipient;
+  final num amount;
+  final String currency;
+  final String? amountSemanticsLabel;
+
+  const _TransferDetailHeader({
+    required this.recipient,
+    required this.amount,
+    required this.currency,
+    this.amountSemanticsLabel,
+  });
+
+  String get amountLabel {
+    final display = AppTextFormatter.formatCurrency(amount, symbol: '');
+    return amountSemanticsLabel ?? 'Transfer amount is $display $currency';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final imageSize = context.dp(60.24.px);
+    final tag = recipient.tag != null
+        ? GtImage(image: recipient.tag!, isDecorative: true)
+        : null;
+
+    final avatar = switch (recipient.imageType) {
+      .image => GtImage(
+        image: recipient.image,
+        width: imageSize,
+        height: imageSize,
+        isDecorative: true,
+        useDefaultSize: false,
+      ),
+      _ => GtAvatar(
+        avatar: recipient.image,
+        size: imageSize,
+        initials: recipient.title.initials,
+        tag: tag,
+        showBorder: true,
+      ),
+    };
+
+    return Column(
+      mainAxisSize: .min,
+      spacing: context.spacingBase,
+      children: [
+        KeyedSubtree(key: const Key('transfer-detail-avatar'), child: avatar),
+        Column(
+          mainAxisSize: .min,
+          spacing: context.spacingSm,
+          children: [
+            GtText(
+              recipient.title,
+              style: context.textStyles.subHeadS(),
+              textAlign: .center,
+              key: const Key('transfer-detail-recipient'),
+            ),
+            GtBalanceText(
+              key: const Key('transfer-detail-amount'),
+              amount: amount,
+              currencySymbol: currency,
+              showVisibilityIcon: false,
+              amountStyle: context.textStyles.h3(heightPx: 40),
+              semanticsLabel: amountLabel,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/organisms/receipts/gt_transfer_detail_body.dart
+++ b/lib/widgets/organisms/receipts/gt_transfer_detail_body.dart
@@ -91,7 +91,8 @@ class GtTransferDetailBody extends GtStatelessWidget {
 
   /// Overrides the label announced for [amount].
   ///
-  /// Defaults to `'Transfer amount is <amount> <currency>'`.
+  /// Defaults to the `transferAmountIs` translation, passed the formatted
+  /// amount as `amount` and [currency] as `currency`.
   final String? amountSemanticsLabel;
 
   /// The actions rendered as a centred row beneath the amount.
@@ -208,13 +209,22 @@ class GtTransferDetailBody extends GtStatelessWidget {
   }
 }
 
-/// The recipient's avatar and name above the transfer amount.
+/// A private widget that renders the head of a [GtTransferDetailBody]: the
+/// recipient's avatar and name above the transfer amount.
 class _TransferDetailHeader extends GtStatelessWidget {
+  /// The recipient whose avatar and name are shown.
   final GtReceiptParticipant recipient;
+
+  /// The raw transfer amount, formatted by [GtBalanceText].
   final num amount;
+
+  /// The currency glyph drawn ahead of [amount].
   final String currency;
+
+  /// Overrides the label announced for [amount]. See [amountLabel].
   final String? amountSemanticsLabel;
 
+  /// Creates a [_TransferDetailHeader].
   const _TransferDetailHeader({
     required this.recipient,
     required this.amount,
@@ -222,9 +232,12 @@ class _TransferDetailHeader extends GtStatelessWidget {
     this.amountSemanticsLabel,
   });
 
+  /// The label announced for [amount]: [amountSemanticsLabel] when supplied,
+  /// otherwise the `transferAmountIs` translation.
   String get amountLabel {
     final display = AppTextFormatter.formatCurrency(amount, symbol: '');
-    return amountSemanticsLabel ?? 'Transfer amount is $display $currency';
+    return amountSemanticsLabel ??
+        'transferAmountIs'.tr({'amount': display, 'currency': currency});
   }
 
   @override

--- a/lib/widgets/organisms/receipts/receipts.dart
+++ b/lib/widgets/organisms/receipts/receipts.dart
@@ -1,3 +1,4 @@
 export 'gt_confirmation_body.dart';
 export 'gt_receipt_body.dart';
 export 'gt_receipt_parts.dart';
+export 'gt_transfer_detail_body.dart';

--- a/lib/widgets/organisms/status/enums/gt_status_tracker_variant.dart
+++ b/lib/widgets/organisms/status/enums/gt_status_tracker_variant.dart
@@ -1,0 +1,22 @@
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// How a [GtStatusTracker] lays out its steps.
+enum GtStatusTrackerVariant {
+  /// Uppercased, state-coloured labels with the subtitle stacked beneath, a
+  /// 16dp node, and a checkmark on a terminal success step.
+  ///
+  /// The track turns green only once every step has succeeded.
+  standard,
+
+  /// A dense timeline for detail cards, rendered by
+  /// [GtStatusTrackerCompactStep]: a 12dp node, the label in its natural
+  /// casing, and the subtitle as a trailing, right-aligned timestamp. A
+  /// terminal success keeps its filled dot rather than swapping to a
+  /// checkmark.
+  ///
+  /// The track turns green once every step before the last has succeeded and
+  /// the last step has been reached — that is, is no longer pending — so a
+  /// transfer that fails or is reversed at its final step still reads as
+  /// having travelled the whole track.
+  compact,
+}

--- a/lib/widgets/organisms/status/gt_status_tracker.dart
+++ b/lib/widgets/organisms/status/gt_status_tracker.dart
@@ -5,6 +5,7 @@ import 'package:gt_mobile_ui/gt_mobile_ui.dart';
 /// A vertical status timeline widget that renders a list of [GtStatusStepData] items.
 ///
 /// Automatically determines connector lines between steps and resolves terminal success checkmarks.
+/// See [GtStatusTrackerVariant] for the available layouts.
 class GtStatusTracker extends GtStatelessWidget {
   /// The ordered list of step data items to display.
   final List<GtStatusStepData> steps;
@@ -12,12 +13,41 @@ class GtStatusTracker extends GtStatelessWidget {
   /// Optional padding around the status tracker list.
   final EdgeInsetsGeometry? padding;
 
+  /// How the steps are laid out. Defaults to [GtStatusTrackerVariant.standard].
+  final GtStatusTrackerVariant variant;
+
   /// Creates a [GtStatusTracker].
-  const GtStatusTracker({super.key, required this.steps, this.padding});
+  const GtStatusTracker({
+    super.key,
+    required this.steps,
+    this.padding,
+    this.variant = .standard,
+  });
 
   @override
   Widget build(BuildContext context) {
     if (!steps.hasValue) return const SizedBox.shrink();
+
+    Widget content = switch (variant) {
+      .standard => _GtStandardStatusTracker(steps),
+      .compact => _GtCompactStatusTracker(steps),
+    };
+
+    if (padding != null) {
+      content = Padding(padding: padding!, child: content);
+    }
+
+    return content;
+  }
+}
+
+class _GtStandardStatusTracker extends GtStatelessWidget {
+  final List<GtStatusStepData> steps;
+
+  const _GtStandardStatusTracker(this.steps);
+
+  @override
+  Widget build(BuildContext context) {
     Color connectorColor = context.palette.stroke.sub;
     final isCompleted = steps.every((it) => it.isSuccess);
 
@@ -25,7 +55,7 @@ class GtStatusTracker extends GtStatelessWidget {
       connectorColor = context.palette.success.darker;
     }
 
-    Widget content = Column(
+    return Column(
       mainAxisSize: .min,
       crossAxisAlignment: .stretch,
       spacing: context.spacingSm,
@@ -41,11 +71,36 @@ class GtStatusTracker extends GtStatelessWidget {
         ],
       ],
     );
+  }
+}
 
-    if (padding != null) {
-      content = Padding(padding: padding!, child: content);
+class _GtCompactStatusTracker extends GtStatelessWidget {
+  final List<GtStatusStepData> steps;
+
+  const _GtCompactStatusTracker(this.steps);
+
+  @override
+  Widget build(BuildContext context) {
+    final lastIndex = steps.length - 1;
+    Color connectorColor = context.palette.stroke.sub;
+    final isTravelled = steps.take(lastIndex).every((it) => it.isSuccess);
+
+    if (isTravelled && !steps.last.isPending) {
+      connectorColor = context.palette.success.base;
     }
 
-    return content;
+    return Column(
+      mainAxisSize: .min,
+      crossAxisAlignment: .stretch,
+      spacing: context.spacingBase,
+      children: [
+        for (final (index, step) in steps.indexed)
+          GtStatusTrackerCompactStep(
+            data: step,
+            connectorColor: index < lastIndex ? connectorColor : null,
+            key: ValueKey((step.label, step.state, index)),
+          ),
+      ],
+    );
   }
 }

--- a/lib/widgets/organisms/status/gt_status_tracker.dart
+++ b/lib/widgets/organisms/status/gt_status_tracker.dart
@@ -41,9 +41,17 @@ class GtStatusTracker extends GtStatelessWidget {
   }
 }
 
+/// A private widget that renders [GtStatusTracker] in its
+/// [GtStatusTrackerVariant.standard] layout.
+///
+/// Stacks a [GtStatusTrackerStep] per step with a
+/// [GtStatusTrackerStepConnector] between each, and turns the connectors
+/// green once every step has succeeded.
 class _GtStandardStatusTracker extends GtStatelessWidget {
+  /// The ordered steps to render. [GtStatusTracker] never passes an empty list.
   final List<GtStatusStepData> steps;
 
+  /// Creates a [_GtStandardStatusTracker].
   const _GtStandardStatusTracker(this.steps);
 
   @override
@@ -74,9 +82,17 @@ class _GtStandardStatusTracker extends GtStatelessWidget {
   }
 }
 
+/// A private widget that renders [GtStatusTracker] in its
+/// [GtStatusTrackerVariant.compact] layout.
+///
+/// Stacks a [GtStatusTrackerCompactStep] per step, each carrying the connector
+/// to the next. The connectors turn green once every step before the last has
+/// succeeded and the last is no longer pending.
 class _GtCompactStatusTracker extends GtStatelessWidget {
+  /// The ordered steps to render. [GtStatusTracker] never passes an empty list.
   final List<GtStatusStepData> steps;
 
+  /// Creates a [_GtCompactStatusTracker].
   const _GtCompactStatusTracker(this.steps);
 
   @override

--- a/lib/widgets/organisms/status/gt_status_tracker_step.dart
+++ b/lib/widgets/organisms/status/gt_status_tracker_step.dart
@@ -184,6 +184,7 @@ class GtStatusTrackerCompactStep extends GtStatelessWidget {
                         weight: .w600,
                         color: palette.text.darkerSub,
                         heightPx: 12,
+                        widthPct: 0,
                       ),
                       maxLines: 1,
                       overflow: .ellipsis,
@@ -195,6 +196,7 @@ class GtStatusTrackerCompactStep extends GtStatelessWidget {
                       style: context.textStyles.subHeadXs(
                         color: subColor,
                         heightPx: 12,
+                        widthPct: 0,
                       ),
                       maxLines: 1,
                     ),

--- a/lib/widgets/organisms/status/gt_status_tracker_step.dart
+++ b/lib/widgets/organisms/status/gt_status_tracker_step.dart
@@ -208,12 +208,21 @@ class GtStatusTrackerCompactStep extends GtStatelessWidget {
   }
 }
 
+/// A private widget that draws a tracker node as a filled or outlined circle.
 class _StatusDot extends StatelessWidget {
+  /// The fill and outline colour.
   final Color color;
+
+  /// Whether the circle is filled with [color] or only outlined.
   final bool filled;
+
+  /// The diameter of the circle.
   final double size;
+
+  /// The width of the outline. Defaults to 2.25, as on the standard tracker.
   final double borderWidth;
 
+  /// Creates a [_StatusDot].
   const _StatusDot({
     required this.color,
     required this.filled,
@@ -235,10 +244,19 @@ class _StatusDot extends StatelessWidget {
   }
 }
 
+/// A private widget that draws the 16dp node of a [GtStatusTrackerStep].
+///
+/// The node follows the step's state, and a terminal success swaps its dot
+/// for a checkmark. An explicit [GtStatusStepData.icon] or
+/// [GtStatusStepData.iconColor] overrides the state.
 class _StatusNode extends StatelessWidget {
+  /// The step whose state and overrides select the node.
   final GtStatusStepData data;
+
+  /// Whether a successful step draws a checkmark rather than a dot.
   final bool showAsTerminalSuccess;
 
+  /// Creates a [_StatusNode].
   const _StatusNode(this.data, {required this.showAsTerminalSuccess});
 
   @override
@@ -269,10 +287,21 @@ class _StatusNode extends StatelessWidget {
   }
 }
 
+/// A private widget that draws the node of a [GtStatusTrackerCompactStep].
+///
+/// The node follows the step's state: a spinner while active, a filled dot on
+/// success, an outlined dot while pending, and an icon once failed or
+/// reversed. Success takes the base green rather than the darker shade the
+/// standard tracker uses, and an explicit [GtStatusStepData.icon] or
+/// [GtStatusStepData.iconColor] overrides the state.
 class _CompactStatusNode extends StatelessWidget {
+  /// The step whose state and overrides select the node.
   final GtStatusStepData data;
+
+  /// The diameter of the node.
   final double size;
 
+  /// Creates a [_CompactStatusNode].
   const _CompactStatusNode(this.data, {required this.size});
 
   @override
@@ -310,11 +339,20 @@ class _CompactStatusNode extends StatelessWidget {
   }
 }
 
+/// A private widget that draws a compact node's glyph at 14dp, centred in and
+/// overhanging the smaller node box, as the design's failed and reversed
+/// glyphs do.
 class _CompactStatusIcon extends StatelessWidget {
+  /// The glyph to draw.
   final IconData icon;
+
+  /// The colour of the glyph.
   final Color color;
+
+  /// The size of the node box the glyph is centred in.
   final double size;
 
+  /// Creates a [_CompactStatusIcon].
   const _CompactStatusIcon(
     this.icon, {
     required this.color,

--- a/lib/widgets/organisms/status/gt_status_tracker_step.dart
+++ b/lib/widgets/organisms/status/gt_status_tracker_step.dart
@@ -113,15 +113,112 @@ class GtStatusTrackerStepConnector extends GtStatelessWidget {
   }
 }
 
+/// Renders a single step row in a [GtStatusTracker] using
+/// [GtStatusTrackerVariant.compact].
+///
+/// Lays out a 12dp node — with an optional connector hanging beneath it — the
+/// label in its natural casing, and the subtitle as a trailing, right-aligned
+/// timestamp. A step without a subtitle, typically a pending one, renders no
+/// timestamp.
+class GtStatusTrackerCompactStep extends GtStatelessWidget {
+  /// The data specifying label, subtitle, state, and explicit color/icon overrides.
+  final GtStatusStepData data;
+
+  /// The colour of the connector drawn beneath the node, leading to the next
+  /// step.
+  ///
+  /// When null no connector is drawn, as for the final step.
+  final Color? connectorColor;
+
+  /// Creates a [GtStatusTrackerCompactStep].
+  const GtStatusTrackerCompactStep({
+    super.key,
+    required this.data,
+    this.connectorColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+    final nodeSize = context.dp(12.px);
+
+    Color subColor = palette.text.sub;
+    if (data.subtitleColor != null) {
+      subColor = data.subtitleColor!;
+    }
+
+    return MergeSemantics(
+      child: Row(
+        crossAxisAlignment: .start,
+        spacing: context.dp(9.px),
+        children: [
+          SizedBox(
+            width: nodeSize,
+            child: Column(
+              mainAxisSize: .min,
+              spacing: context.spacingSm,
+              children: [
+                _CompactStatusNode(data, size: nodeSize),
+                if (connectorColor case Color color)
+                  Container(
+                    width: context.dp(2.px),
+                    height: context.dp(8.px),
+                    decoration: BoxDecoration(
+                      color: color,
+                      borderRadius: context.borderRadiusXs,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: context.insets.symmetricDp(vertical: 1.px),
+              child: Row(
+                spacing: context.spacingBase,
+                children: [
+                  Expanded(
+                    child: GtText(
+                      data.label,
+                      style: context.textStyles.subHeadXs(
+                        weight: .w600,
+                        color: palette.text.darkerSub,
+                        heightPx: 12,
+                      ),
+                      maxLines: 1,
+                      overflow: .ellipsis,
+                    ),
+                  ),
+                  if (data.subtitle.hasValue)
+                    GtText(
+                      data.subtitle.value,
+                      style: context.textStyles.subHeadXs(
+                        color: subColor,
+                        heightPx: 12,
+                      ),
+                      maxLines: 1,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _StatusDot extends StatelessWidget {
   final Color color;
   final bool filled;
   final double size;
+  final double borderWidth;
 
   const _StatusDot({
     required this.color,
     required this.filled,
     required this.size,
+    this.borderWidth = 2.25,
   });
 
   @override
@@ -132,7 +229,7 @@ class _StatusDot extends StatelessWidget {
       decoration: BoxDecoration(
         color: filled ? color : Colors.transparent,
         shape: BoxShape.circle,
-        border: Border.all(color: color, width: 2.25),
+        border: Border.all(color: color, width: borderWidth),
       ),
     );
   }
@@ -169,5 +266,72 @@ class _StatusNode extends StatelessWidget {
       .outlineDot => _StatusDot(color: nodeColor, filled: false, size: size),
       .icon => GtIcon.withColor(data.state.icon, color: nodeColor, size: size),
     };
+  }
+}
+
+class _CompactStatusNode extends StatelessWidget {
+  final GtStatusStepData data;
+  final double size;
+
+  const _CompactStatusNode(this.data, {required this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.palette;
+
+    Color stateColor = data.state.color(palette);
+    if (data.isSuccess) stateColor = palette.success.base;
+
+    final nodeColor = data.iconColor ?? stateColor;
+
+    if (data.icon != null) {
+      return _CompactStatusIcon(data.icon!, color: nodeColor, size: size);
+    }
+
+    return switch (data.state.nodeKind) {
+      .spinner => GtSpinner(
+        color: nodeColor,
+        size: size,
+        strokeWidth: context.dp(2.px),
+      ),
+      .filledDot => _StatusDot(color: nodeColor, filled: true, size: size),
+      .outlineDot => _StatusDot(
+        color: nodeColor,
+        filled: false,
+        size: size,
+        borderWidth: 1.5,
+      ),
+      .icon => _CompactStatusIcon(
+        data.state.icon,
+        color: nodeColor,
+        size: size,
+      ),
+    };
+  }
+}
+
+class _CompactStatusIcon extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final double size;
+
+  const _CompactStatusIcon(
+    this.icon, {
+    required this.color,
+    required this.size,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final iconSize = context.dp(14.px);
+
+    return SizedBox.square(
+      dimension: size,
+      child: OverflowBox(
+        maxWidth: iconSize,
+        maxHeight: iconSize,
+        child: GtIcon.withColor(icon, color: color, size: iconSize),
+      ),
+    );
   }
 }

--- a/lib/widgets/organisms/status/status.dart
+++ b/lib/widgets/organisms/status/status.dart
@@ -1,3 +1,4 @@
 export 'enums/enums.dart';
+export 'enums/gt_status_tracker_variant.dart';
 export 'gt_status_tracker.dart';
 export 'gt_status_tracker_step.dart';

--- a/lib/widgets/templates/scaffolds/gt_dashboard_scaffold.dart
+++ b/lib/widgets/templates/scaffolds/gt_dashboard_scaffold.dart
@@ -127,7 +127,7 @@ class _GtDashboardScaffoldState extends State<GtDashboardScaffold> {
   Widget build(BuildContext context) {
     final pages = widget.data.pages;
     final navItems = widget.data.navItems;
-    final gradiantStart = switch(context.isInDarkMode) {
+    final gradiantStart = switch (context.isInDarkMode) {
       true => context.palette.primary.darker,
       _ => context.palette.primary.base,
     };

--- a/lib/widgets/templates/scaffolds/gt_transfer_detail_scaffold.dart
+++ b/lib/widgets/templates/scaffolds/gt_transfer_detail_scaffold.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+/// A scaffold template for transfer detail screens.
+///
+/// Wraps a [GtTransferDetailBody] in a [GtPopScope] and a transparent
+/// [Scaffold], and shares the layout of [GtReceiptScaffold]:
+/// - An action app bar ([GtActionAppBar]) with an optional download icon button ([GtIcons.download]) on the left and a close button ([GtCancelButton]) on the right.
+/// - The body, stacked beneath a floating bottom navigation bar
+///   ([GtButtonBottomNavBar]) whose action button defaults to
+///   "Report a Problem".
+///
+/// It is designed to be presented modally, typically via
+/// `GtBottomSheetMixin.showDraggableSheet`.
+///
+/// Example usage:
+/// ```dart
+/// showDraggableSheet(
+///   context,
+///   initialChildSize: .9,
+///   builder: (controller) {
+///     return GtTransferDetailScaffold(
+///       onClose: () => GtRouter.popView(),
+///       onReportProblem: () => handleReportProblem(),
+///       body: GtTransferDetailBody(
+///         controller: controller,
+///         amount: 20000,
+///         recipient: recipient,
+///         steps: steps,
+///         sections: sections,
+///       ),
+///     );
+///   },
+/// );
+/// ```
+class GtTransferDetailScaffold extends GtStatelessWidget {
+  /// The main body content widget displayed inside the scaffold.
+  final GtTransferDetailBody body;
+
+  /// Callback executed when the bottom action button (e.g., "Report a Problem") is pressed.
+  final OnPressed onReportProblem;
+
+  /// Callback executed when the close button in the top action bar is pressed.
+  final OnPressed onClose;
+
+  /// Custom label text for the bottom action button.
+  ///
+  /// If null, defaults to localized `"reportAProblem"`.
+  final String? buttonText;
+
+  /// Custom text color for the bottom action button.
+  ///
+  /// If null, defaults to [context.palette.text.white].
+  final Color? buttonTextColor;
+
+  /// Custom background color for the bottom action button.
+  ///
+  /// If null, defaults to [context.palette.bg.sub].
+  final Color? buttonBackgroundColor;
+
+  /// Optional icon to display for the download action button.
+  ///
+  /// If null, defaults to [GtIcons.download].
+  final IconData? downloadIcon;
+
+  /// Optional callback executed when the download icon button in the top app bar is pressed.
+  ///
+  /// If provided, a download icon button will be rendered on the left of the app bar.
+  /// If null, no leading widget is displayed.
+  final OnPressed? onDownload;
+
+  /// Creates a [GtTransferDetailScaffold].
+  ///
+  /// The [body], [onClose], and [onReportProblem] parameters are required.
+  const GtTransferDetailScaffold({
+    super.key,
+    required this.body,
+    required this.onClose,
+    required this.onReportProblem,
+    this.buttonText,
+    this.buttonTextColor,
+    this.buttonBackgroundColor,
+    this.downloadIcon,
+    this.onDownload,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget? leading;
+
+    if (onDownload != null) {
+      leading = GtIconButton(
+        icon: downloadIcon ?? GtIcons.download,
+        onPressed: onDownload!,
+        contentPadding: .zero,
+        iconColor: context.palette.icon.strong,
+        color: context.palette.staticColors.transparent,
+      );
+    }
+
+    return GtPopScope(
+      canPop: false,
+      child: Scaffold(
+        backgroundColor: context.palette.staticColors.transparent,
+        appBar: GtActionAppBar(
+          implyLeading: false,
+          leading: leading,
+          trailing: GtOptionalWidgetPair(tail: GtCancelButton(onTap: onClose)),
+        ),
+        body: Stack(
+          children: [
+            Positioned.fill(child: body),
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: GtButtonBottomNavBar(
+                button: GtRaisedButton(
+                  onPressed: onReportProblem,
+                  text: buttonText ?? "reportAProblem".utr(),
+                  variant: .neutralAlt,
+                  alignment: .center,
+                  size: .small,
+                  textColor: buttonTextColor ?? context.palette.text.white,
+                  color: buttonBackgroundColor ?? context.palette.bg.sub,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/templates/scaffolds/scaffolds.dart
+++ b/lib/widgets/templates/scaffolds/scaffolds.dart
@@ -2,3 +2,4 @@ export 'gt_confirmation_scaffold.dart';
 export 'gt_dashboard_scaffold.dart';
 export 'gt_receipt_scaffold.dart';
 export 'gt_summary_scaffold.dart';
+export 'gt_transfer_detail_scaffold.dart';

--- a/test/gt_balance_text_test.dart
+++ b/test/gt_balance_text_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return GtThemeProvider(
+      theme: kPersonalTheme,
+      child: MaterialApp(
+        home: Scaffold(body: Center(child: child)),
+      ),
+    );
+  }
+
+  group('GtBalanceText visibility icon', () {
+    testWidgets('shows the icon and toggles on tap by default', (tester) async {
+      var taps = 0;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtBalanceText(amount: 12, onVisibilityIconTap: () => taps++),
+        ),
+      );
+
+      expect(find.byIcon(GtIcons.eyeClosed), findsOneWidget);
+      expect(find.byType(GtInkWell), findsOneWidget);
+
+      await tester.tap(find.byType(GtBalanceText));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('omits the icon and the tap target when hidden', (
+      tester,
+    ) async {
+      var taps = 0;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtBalanceText(
+            amount: 12,
+            showVisibilityIcon: false,
+            onVisibilityIconTap: () => taps++,
+          ),
+        ),
+      );
+
+      expect(find.byIcon(GtIcons.eyeClosed), findsNothing);
+      expect(find.byIcon(GtIcons.eyeOpen), findsNothing);
+      expect(find.byType(GtInkWell), findsNothing);
+      expect(find.byType(GtTapTarget), findsNothing);
+
+      await tester.tap(find.byType(GtBalanceText));
+      await tester.pumpAndSettle();
+
+      expect(taps, 0);
+    });
+
+    testWidgets('still masks the amount without the icon', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const GtBalanceText(
+            amount: 12,
+            hidden: true,
+            showVisibilityIcon: false,
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(
+        find
+            .descendant(
+              of: find.byType(GtBalanceText),
+              matching: find.byType(Text),
+            )
+            .first,
+      );
+      expect(text.textSpan?.toPlainText(), contains('********'));
+      expect(find.byIcon(GtIcons.eyeOpen), findsNothing);
+    });
+
+    testWidgets('omits the icon from animated amounts', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const GtBalanceText(
+            amount: 12,
+            animateChanges: true,
+            showVisibilityIcon: false,
+          ),
+        ),
+      );
+
+      expect(find.byType(GtAnimatedCounter), findsOneWidget);
+      expect(find.byIcon(GtIcons.eyeClosed), findsNothing);
+    });
+  });
+}

--- a/test/gt_marquee_scroll_physics_test.dart
+++ b/test/gt_marquee_scroll_physics_test.dart
@@ -84,93 +84,101 @@ void main() {
       expect(sim, isNull);
     });
 
-    test('adjustPositionForNewDimensions triggers ballistic kick off on initial layout', () {
-      const physics = GtMarqueeScrollPhysics();
+    test(
+      'adjustPositionForNewDimensions triggers ballistic kick off on initial layout',
+      () {
+        const physics = GtMarqueeScrollPhysics();
 
-      final oldPosition = FixedScrollMetrics(
-        minScrollExtent: 0,
-        maxScrollExtent: 0,
-        pixels: 0,
-        viewportDimension: 100,
-        axisDirection: AxisDirection.right,
-        devicePixelRatio: 1,
-      );
+        final oldPosition = FixedScrollMetrics(
+          minScrollExtent: 0,
+          maxScrollExtent: 0,
+          pixels: 0,
+          viewportDimension: 100,
+          axisDirection: AxisDirection.right,
+          devicePixelRatio: 1,
+        );
 
-      final newPosition = FixedScrollMetrics(
-        minScrollExtent: 0,
-        maxScrollExtent: 50,
-        pixels: 0,
-        viewportDimension: 100,
-        axisDirection: AxisDirection.right,
-        devicePixelRatio: 1,
-      );
+        final newPosition = FixedScrollMetrics(
+          minScrollExtent: 0,
+          maxScrollExtent: 50,
+          pixels: 0,
+          viewportDimension: 100,
+          axisDirection: AxisDirection.right,
+          devicePixelRatio: 1,
+        );
 
-      final newPixels = physics.adjustPositionForNewDimensions(
-        oldPosition: oldPosition,
-        newPosition: newPosition,
-        isScrolling: false,
-        velocity: 0,
-      );
+        final newPixels = physics.adjustPositionForNewDimensions(
+          oldPosition: oldPosition,
+          newPosition: newPosition,
+          isScrolling: false,
+          velocity: 0,
+        );
 
-      expect(newPixels, isNot(equals(0.0)));
-    });
+        expect(newPixels, isNot(equals(0.0)));
+      },
+    );
 
-    testWidgets('SingleChildScrollView with GtMarqueeScrollPhysics scrolls back and forth', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 100,
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                physics: const GtMarqueeScrollPhysics(
-                  marqueeVelocity: 50.0,
-                  pauseDuration: Duration(milliseconds: 500),
-                ),
-                child: const SizedBox(
-                  width: 300,
-                  height: 50,
-                  child: Text('Long overflowing marquee text that scrolls continuously'),
+    testWidgets(
+      'SingleChildScrollView with GtMarqueeScrollPhysics scrolls back and forth',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 100,
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  physics: const GtMarqueeScrollPhysics(
+                    marqueeVelocity: 50.0,
+                    pauseDuration: Duration(milliseconds: 500),
+                  ),
+                  child: const SizedBox(
+                    width: 300,
+                    height: 50,
+                    child: Text(
+                      'Long overflowing marquee text that scrolls continuously',
+                    ),
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-      );
+        );
 
-      final scrollable = find.byType(Scrollable);
-      expect(scrollable, findsOneWidget);
+        final scrollable = find.byType(Scrollable);
+        expect(scrollable, findsOneWidget);
 
-      // Initial render: at 0
-      ScrollableState state = tester.state(scrollable);
-      expect(state.position.pixels, closeTo(0, 0.01));
+        // Initial render: at 0
+        ScrollableState state = tester.state(scrollable);
+        expect(state.position.pixels, closeTo(0, 0.01));
 
-      // After 500ms pause: still around 0
-      await tester.pump(const Duration(milliseconds: 500));
-      state = tester.state(scrollable);
-      expect(state.position.pixels, closeTo(0, 0.01));
+        // After 500ms pause: still around 0
+        await tester.pump(const Duration(milliseconds: 500));
+        state = tester.state(scrollable);
+        expect(state.position.pixels, closeTo(0, 0.01));
 
-      // After 2000ms: maxScrollExtent is 200 (300 - 100).
-      // Time to scroll 200px at 50px/s is 4s (4000ms).
-      // At 500ms pause + 2000ms scroll: pixels should be around 100.
-      await tester.pump(const Duration(milliseconds: 2000));
-      state = tester.state(scrollable);
-      expect(state.position.pixels, closeTo(100, 1.0));
+        // After 2000ms: maxScrollExtent is 200 (300 - 100).
+        // Time to scroll 200px at 50px/s is 4s (4000ms).
+        // At 500ms pause + 2000ms scroll: pixels should be around 100.
+        await tester.pump(const Duration(milliseconds: 2000));
+        state = tester.state(scrollable);
+        expect(state.position.pixels, closeTo(100, 1.0));
 
-      // Complete forward scroll (total 500ms + 4000ms = 4500ms)
-      await tester.pump(const Duration(milliseconds: 2000));
-      state = tester.state(scrollable);
-      expect(state.position.pixels, closeTo(200, 1.0));
+        // Complete forward scroll (total 500ms + 4000ms = 4500ms)
+        await tester.pump(const Duration(milliseconds: 2000));
+        state = tester.state(scrollable);
+        expect(state.position.pixels, closeTo(200, 1.0));
 
-      // Reversal: after end pause (500ms) and 2000ms backward scroll -> should be around 100
-      await tester.pump(const Duration(milliseconds: 2500));
-      state = tester.state(scrollable);
-      expect(state.position.pixels, closeTo(100, 1.0));
+        // Reversal: after end pause (500ms) and 2000ms backward scroll -> should be around 100
+        await tester.pump(const Duration(milliseconds: 2500));
+        state = tester.state(scrollable);
+        expect(state.position.pixels, closeTo(100, 1.0));
 
-      // Complete backward scroll -> back at 0
-      await tester.pump(const Duration(milliseconds: 2000));
-      state = tester.state(scrollable);
-      expect(state.position.pixels, closeTo(0, 1.0));
-    });
+        // Complete backward scroll -> back at 0
+        await tester.pump(const Duration(milliseconds: 2000));
+        state = tester.state(scrollable);
+        expect(state.position.pixels, closeTo(0, 1.0));
+      },
+    );
   });
 }

--- a/test/gt_motion_test.dart
+++ b/test/gt_motion_test.dart
@@ -60,7 +60,7 @@ void main() {
     );
 
     expect(find.byType(GtAnimatedCounter), findsOneWidget);
-    expect(find.bySemanticsLabel('12.00 Naira'), findsOneWidget);
+    expect(find.bySemanticsLabel('Balance is 12.00 ₦'), findsOneWidget);
 
     await tester.pumpWidget(
       const _MotionTestApp(
@@ -70,7 +70,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(SlideTransition), findsWidgets);
-    expect(find.bySemanticsLabel('34.00 Naira'), findsOneWidget);
+    expect(find.bySemanticsLabel('Balance is 34.00 ₦'), findsOneWidget);
   });
 
   testWidgets('GtBalanceText keeps masked balances static', (tester) async {

--- a/test/gt_signature_pad_test.dart
+++ b/test/gt_signature_pad_test.dart
@@ -294,10 +294,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        _SignaturePadTestApp(
-          controller: controller,
-          onSecondaryAction: () {},
-        ),
+        _SignaturePadTestApp(controller: controller, onSecondaryAction: () {}),
       );
 
       expect(find.text('Tap to draw your signature'), findsOneWidget);

--- a/test/gt_status_tracker_test.dart
+++ b/test/gt_status_tracker_test.dart
@@ -166,6 +166,22 @@ void main() {
       expect(find.byType(GtSpinner), findsOneWidget);
     });
 
+    testWidgets('drops the subHeadXs tracking from its text', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget([step(GtStatusStepState.success, subtitle: timestamp)]),
+      );
+
+      final textStyles = tester
+          .element(find.byType(GtStatusTracker))
+          .textStyles;
+      expect(textStyles.subHeadXs().letterSpacing, closeTo(0.48, 1e-9));
+
+      final label = tester.widget<Text>(find.text('success'));
+      final subtitle = tester.widget<Text>(find.text(timestamp));
+      expect(label.style?.letterSpacing, 0);
+      expect(subtitle.style?.letterSpacing, 0);
+    });
+
     testWidgets('keeps a filled dot rather than a terminal checkmark', (
       tester,
     ) async {
@@ -241,11 +257,11 @@ void main() {
         );
 
         final green = paletteOf(tester).success.base;
-        expect(connectorColors(tester), [
-          green,
-          green,
-          null,
-        ], reason: 'expected a green track ending in ${outcome.name}');
+        expect(
+          connectorColors(tester),
+          [green, green, null],
+          reason: 'expected a green track ending in ${outcome.name}',
+        );
       }
     });
   });

--- a/test/gt_status_tracker_test.dart
+++ b/test/gt_status_tracker_test.dart
@@ -95,4 +95,158 @@ void main() {
       expect(secondStep.showAsTerminalSuccess, isFalse);
     });
   });
+
+  group('GtStatusTracker compact variant', () {
+    const timestamp = 'Sep 10, 2025 11:03 AM';
+
+    Widget buildTestWidget(List<GtStatusStepData> steps) {
+      return GtThemeProvider(
+        theme: kPersonalTheme,
+        child: MaterialApp(
+          home: Scaffold(
+            body: GtStatusTracker(
+              steps: steps,
+              variant: GtStatusTrackerVariant.compact,
+            ),
+          ),
+        ),
+      );
+    }
+
+    GtStatusStepData step(GtStatusStepState state, {String? subtitle}) {
+      return GtStatusStepData(
+        label: state.name,
+        state: state,
+        subtitle: subtitle,
+      );
+    }
+
+    List<Color?> connectorColors(WidgetTester tester) {
+      return tester
+          .widgetList<GtStatusTrackerCompactStep>(
+            find.byType(GtStatusTrackerCompactStep),
+          )
+          .map((it) => it.connectorColor)
+          .toList();
+    }
+
+    GtPalette paletteOf(WidgetTester tester) {
+      return tester.element(find.byType(GtStatusTracker)).palette;
+    }
+
+    testWidgets('renders labels as supplied with trailing timestamps', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(const [
+          GtStatusStepData(
+            label: 'Processed',
+            state: GtStatusStepState.success,
+            subtitle: timestamp,
+          ),
+          GtStatusStepData(
+            label: 'Sending',
+            state: GtStatusStepState.active,
+            subtitle: timestamp,
+          ),
+          GtStatusStepData(
+            label: 'Delivered',
+            state: GtStatusStepState.pending,
+          ),
+        ]),
+      );
+
+      expect(find.byType(GtStatusTrackerCompactStep), findsNWidgets(3));
+      expect(find.byType(GtStatusTrackerStep), findsNothing);
+      expect(find.text('Processed'), findsOneWidget);
+      expect(find.text('PROCESSED'), findsNothing);
+      expect(find.text('Delivered'), findsOneWidget);
+      // The pending step carries no subtitle, so only two timestamps render.
+      expect(find.text(timestamp), findsNWidgets(2));
+      expect(find.byType(GtSpinner), findsOneWidget);
+    });
+
+    testWidgets('keeps a filled dot rather than a terminal checkmark', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget([
+          step(GtStatusStepState.success),
+          step(GtStatusStepState.success),
+          step(GtStatusStepState.success),
+        ]),
+      );
+
+      expect(find.byIcon(GtIcons.checkSolid), findsNothing);
+    });
+
+    testWidgets('draws no connector beneath the final step', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget([
+          step(GtStatusStepState.success),
+          step(GtStatusStepState.success),
+        ]),
+      );
+
+      expect(connectorColors(tester).last, isNull);
+    });
+
+    testWidgets('greys the track while a middle step is in flight', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget([
+          step(GtStatusStepState.success),
+          step(GtStatusStepState.active),
+          step(GtStatusStepState.pending),
+        ]),
+      );
+
+      final grey = paletteOf(tester).stroke.sub;
+      expect(connectorColors(tester), [grey, grey, null]);
+    });
+
+    testWidgets('greys the track after a failure short of the last step', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget([
+          step(GtStatusStepState.success),
+          step(GtStatusStepState.failed),
+          step(GtStatusStepState.reversed),
+        ]),
+      );
+
+      final grey = paletteOf(tester).stroke.sub;
+      expect(connectorColors(tester), [grey, grey, null]);
+    });
+
+    testWidgets('greens the track once the last step is reached', (
+      tester,
+    ) async {
+      final outcomes = [
+        GtStatusStepState.active,
+        GtStatusStepState.success,
+        GtStatusStepState.failed,
+        GtStatusStepState.reversed,
+      ];
+
+      for (final outcome in outcomes) {
+        await tester.pumpWidget(
+          buildTestWidget([
+            step(GtStatusStepState.success),
+            step(GtStatusStepState.success),
+            step(outcome),
+          ]),
+        );
+
+        final green = paletteOf(tester).success.base;
+        expect(connectorColors(tester), [
+          green,
+          green,
+          null,
+        ], reason: 'expected a green track ending in ${outcome.name}');
+      }
+    });
+  });
 }

--- a/test/gt_transfer_detail_test.dart
+++ b/test/gt_transfer_detail_test.dart
@@ -1,0 +1,455 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gt_mobile_foundation/foundation.dart';
+import 'package:gt_mobile_ui/gt_mobile_ui.dart';
+
+void main() {
+  Widget buildTestWidget(Widget child) {
+    return GtThemeProvider(
+      theme: kPersonalTheme,
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
+  }
+
+  Future<void> tapAndSettle(WidgetTester tester, Finder finder) async {
+    await tester.tap(finder);
+    await tester.pumpAndSettle();
+  }
+
+  const timestamp = 'Sep 10, 2025 11:03 AM';
+
+  // Every step is settled so no spinner animates, which lets tests settle.
+  const steps = [
+    GtStatusStepData(
+      label: 'Processed',
+      state: GtStatusStepState.success,
+      subtitle: timestamp,
+    ),
+    GtStatusStepData(
+      label: 'Sent',
+      state: GtStatusStepState.success,
+      subtitle: timestamp,
+    ),
+    GtStatusStepData(
+      label: 'Delivered',
+      state: GtStatusStepState.success,
+      subtitle: timestamp,
+    ),
+  ];
+
+  const sections = [
+    GtTransferDetailSection(
+      tiles: [
+        GtReceiptTileData(
+          label: 'Category',
+          value: 'Transfer',
+          image: AppImageData(GtVectors.logo),
+        ),
+        GtReceiptTileData(label: 'Source Account', value: 'Savings · 102029'),
+      ],
+    ),
+    GtTransferDetailSection(
+      tiles: [
+        GtReceiptTileData(label: 'Reference', value: 'TRX24072983910527NGN'),
+      ],
+    ),
+  ];
+
+  const recipient = GtReceiptParticipant(
+    title: 'Frances Nkatie',
+    image: AppImageData(GtVectors.logo),
+  );
+
+  GtTransferDetailBody buildBody({
+    List<GtStatusStepData> steps = steps,
+    List<GtTransferDetailSection> sections = sections,
+    List<GtReceiptAction> actions = const [],
+    String currency = AppStrings.naira,
+    String? amountSemanticsLabel,
+  }) {
+    return GtTransferDetailBody(
+      recipient: recipient,
+      amount: 20000,
+      currency: currency,
+      amountSemanticsLabel: amountSemanticsLabel,
+      steps: steps,
+      sections: sections,
+      actions: actions,
+    );
+  }
+
+  Finder tileIn(String key) {
+    return find.descendant(
+      of: find.byKey(Key(key)),
+      matching: find.byType(GtDoubleColumnListTile),
+    );
+  }
+
+  group('GtTransferDetailBody', () {
+    testWidgets('renders the recipient, currency and amount', (tester) async {
+      await tester.pumpWidget(buildTestWidget(buildBody()));
+
+      expect(find.byKey(const Key('transfer-detail-avatar')), findsOneWidget);
+      expect(find.text('Frances Nkatie'), findsOneWidget);
+      expect(find.text('${AppStrings.naira} '), findsOneWidget);
+
+      final amount = tester.widget<GtBalanceText>(
+        find.byKey(const Key('transfer-detail-amount')),
+      );
+      expect(amount.amtDisplay, '20,000.00');
+      expect(amount.showVisibilityIcon, isFalse);
+      expect(find.byIcon(GtIcons.eyeClosed), findsNothing);
+      expect(find.byIcon(GtIcons.eyeOpen), findsNothing);
+    });
+
+    testWidgets('announces the amount as a transfer amount', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(buildTestWidget(buildBody()));
+
+      // The header merges into a single node, so match within its label.
+      expect(
+        find.bySemanticsLabel(
+          RegExp('Transfer amount is 20,000.00 ${AppStrings.naira}'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel(RegExp('Balance is')), findsNothing);
+
+      await tester.pumpWidget(
+        buildTestWidget(buildBody(amountSemanticsLabel: 'You sent 20,000')),
+      );
+
+      expect(find.bySemanticsLabel(RegExp('You sent 20,000')), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    testWidgets('renders a custom currency', (tester) async {
+      await tester.pumpWidget(buildTestWidget(buildBody(currency: r'$')));
+
+      expect(find.text(r'$ '), findsOneWidget);
+      expect(find.text('${AppStrings.naira} '), findsNothing);
+    });
+
+    testWidgets('renders an avatar with its tag for avatar recipients', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const GtTransferDetailBody(
+            recipient: GtReceiptParticipant(
+              title: 'Frances Nkatie',
+              image: AppImageData(GtAssetImages.avatar),
+              imageType: GtReceiptImageType.avatar,
+              tag: AppImageData(GtVectors.logo),
+            ),
+            amount: 20000,
+            steps: steps,
+          ),
+        ),
+      );
+
+      final avatar = tester.widget<GtAvatar>(find.byType(GtAvatar));
+      expect(avatar.tag, isNotNull);
+      expect(avatar.showBorder, isTrue);
+    });
+
+    testWidgets('renders the steps in a compact status tracker', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget(buildBody()));
+
+      expect(find.byKey(const Key('transfer-detail-status')), findsOneWidget);
+
+      final tracker = tester.widget<GtStatusTracker>(
+        find.byType(GtStatusTracker),
+      );
+      expect(tracker.variant, GtStatusTrackerVariant.compact);
+      expect(find.text('Processed'), findsOneWidget);
+      expect(find.text(timestamp), findsNWidgets(3));
+    });
+
+    testWidgets('omits the status card when there are no steps', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget(buildBody(steps: const [])));
+
+      expect(find.byKey(const Key('transfer-detail-status')), findsNothing);
+    });
+
+    testWidgets('renders one card per section with keyed tiles', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget(buildBody()));
+
+      expect(
+        find.byKey(const Key('transfer-detail-section-0')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('transfer-detail-section-1')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('transfer-detail-section-2')), findsNothing);
+
+      expect(
+        find.byKey(const Key('transfer-detail-section-0-tile-1')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('transfer-detail-section-1-tile-0')),
+        findsOneWidget,
+      );
+      expect(find.text('TRX24072983910527NGN'), findsOneWidget);
+    });
+
+    testWidgets('emphasises values and leads them with row images', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget(buildBody()));
+
+      final category = tester.widget<GtDoubleColumnListTile>(
+        tileIn('transfer-detail-section-0-tile-0'),
+      );
+      expect(category.highlightValue, isTrue);
+      expect(category.valuePrefix, isNotNull);
+      expect(category.valueSuffix, isNull);
+    });
+
+    testWidgets('renders the actions and invokes them', (tester) async {
+      var taps = 0;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          buildBody(
+            actions: [
+              GtReceiptAction.primary(
+                label: 'Send again',
+                icon: GtIcons.arrowNorthEast,
+                onTap: () => taps++,
+              ),
+              GtReceiptAction(
+                label: 'View receipt',
+                icon: GtIcons.fileContent,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.byType(GtReceiptActionButton), findsNWidgets(2));
+
+      await tapAndSettle(
+        tester,
+        find.byKey(const Key('transfer-detail-action-0')),
+      );
+
+      expect(taps, 1);
+    });
+
+    testWidgets('omits the action row when there are no actions', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget(buildBody()));
+
+      expect(find.byType(GtReceiptActionButton), findsNothing);
+    });
+
+    testWidgets('asserts when a section has no tiles', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          buildBody(sections: const [GtTransferDetailSection(tiles: [])]),
+        ),
+      );
+
+      expect(tester.takeException(), isAssertionError);
+    });
+  });
+
+  group('GtReceiptDetailTile', () {
+    testWidgets('keeps label emphasis and trailing images by default', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const GtReceiptDetailTile(
+            GtReceiptTileData(
+              label: 'Category',
+              value: 'Transfer',
+              image: AppImageData(GtVectors.logo),
+            ),
+          ),
+        ),
+      );
+
+      final tile = tester.widget<GtDoubleColumnListTile>(
+        find.byType(GtDoubleColumnListTile),
+      );
+      expect(tile.highlightValue, isFalse);
+      expect(tile.valueSuffix, isNotNull);
+      expect(tile.valuePrefix, isNull);
+      expect(tile.labelSuffix, isNull);
+    });
+
+    testWidgets('renders an info icon only when onInfoTap is supplied', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          const GtReceiptDetailTile(
+            GtReceiptTileData(label: 'Stamp duty', value: '₦50'),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('receipt-tile-info')), findsNothing);
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtReceiptDetailTile(
+            GtReceiptTileData(
+              label: 'Stamp duty',
+              value: '₦50',
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('receipt-tile-info')), findsOneWidget);
+    });
+
+    testWidgets('invokes onInfoTap without invoking onTap', (tester) async {
+      var infoTaps = 0;
+      var rowTaps = 0;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtReceiptDetailTile(
+            GtReceiptTileData(
+              label: 'Fees (VAT Incl)',
+              value: '₦25',
+              onTap: () => rowTaps++,
+              onInfoTap: () => infoTaps++,
+            ),
+          ),
+        ),
+      );
+
+      await tapAndSettle(tester, find.byKey(const Key('receipt-tile-info')));
+
+      expect(infoTaps, 1);
+      expect(rowTaps, 0);
+    });
+
+    testWidgets('announces the info icon to screen readers', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtReceiptDetailTile(
+            GtReceiptTileData(
+              label: 'Fees (VAT Incl)',
+              value: '₦25',
+              onInfoTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.bySemanticsLabel('More information about Fees (VAT Incl)'),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          GtReceiptDetailTile(
+            GtReceiptTileData(
+              label: 'Fees (VAT Incl)',
+              value: '₦25',
+              onInfoTap: () {},
+              infoSemanticsLabel: 'How fees are calculated',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('How fees are calculated'), findsOneWidget);
+
+      handle.dispose();
+    });
+  });
+
+  group('GtTransferDetailScaffold', () {
+    Widget buildScaffold({
+      VoidCallback? onClose,
+      VoidCallback? onReportProblem,
+      OnPressed? onDownload,
+    }) {
+      return GtThemeProvider(
+        theme: kPersonalTheme,
+        child: MaterialApp(
+          home: GtTransferDetailScaffold(
+            onClose: onClose ?? () {},
+            onReportProblem: onReportProblem ?? () {},
+            onDownload: onDownload,
+            buttonText: 'Report a problem',
+            body: buildBody(),
+          ),
+        ),
+      );
+    }
+
+    Finder reportButton() {
+      return find.descendant(
+        of: find.byType(GtButtonBottomNavBar),
+        matching: find.byType(GtRaisedButton),
+      );
+    }
+
+    testWidgets('renders the body beneath the bottom bar', (tester) async {
+      await tester.pumpWidget(buildScaffold());
+
+      expect(find.byType(GtTransferDetailBody), findsOneWidget);
+      expect(reportButton(), findsOneWidget);
+    });
+
+    testWidgets('routes the close button to onClose', (tester) async {
+      var closes = 0;
+      await tester.pumpWidget(buildScaffold(onClose: () => closes++));
+
+      await tapAndSettle(tester, find.byType(GtCancelButton));
+
+      expect(closes, 1);
+    });
+
+    testWidgets('routes the bottom action to onReportProblem', (tester) async {
+      var reports = 0;
+      await tester.pumpWidget(buildScaffold(onReportProblem: () => reports++));
+
+      await tapAndSettle(tester, reportButton());
+
+      expect(reports, 1);
+    });
+
+    testWidgets('renders the download action only when onDownload is set', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildScaffold());
+
+      expect(find.byIcon(GtIcons.download), findsNothing);
+
+      var downloads = 0;
+      await tester.pumpWidget(buildScaffold(onDownload: () => downloads++));
+
+      expect(find.byIcon(GtIcons.download), findsOneWidget);
+
+      await tapAndSettle(tester, find.byIcon(GtIcons.download));
+
+      expect(downloads, 1);
+    });
+  });
+}

--- a/test/gt_transfer_detail_test.dart
+++ b/test/gt_transfer_detail_test.dart
@@ -107,13 +107,9 @@ void main() {
 
       await tester.pumpWidget(buildTestWidget(buildBody()));
 
-      // The header merges into a single node, so match within its label.
-      expect(
-        find.bySemanticsLabel(
-          RegExp('Transfer amount is 20,000.00 ${AppStrings.naira}'),
-        ),
-        findsOneWidget,
-      );
+      // Tests load no translations, so `tr` falls back to the key. The header
+      // also merges into a single node, so match within its label.
+      expect(find.bySemanticsLabel(RegExp('transferAmountIs')), findsOneWidget);
       expect(find.bySemanticsLabel(RegExp('Balance is')), findsNothing);
 
       await tester.pumpWidget(
@@ -359,10 +355,8 @@ void main() {
         ),
       );
 
-      expect(
-        find.bySemanticsLabel('More information about Fees (VAT Incl)'),
-        findsOneWidget,
-      );
+      // Tests load no translations, so `tr` falls back to the key.
+      expect(find.bySemanticsLabel('moreInfoAbout'), findsOneWidget);
 
       await tester.pumpWidget(
         buildTestWidget(

--- a/test/gt_transfer_detail_test.dart
+++ b/test/gt_transfer_detail_test.dart
@@ -149,6 +149,18 @@ void main() {
       final avatar = tester.widget<GtAvatar>(find.byType(GtAvatar));
       expect(avatar.tag, isNotNull);
       expect(avatar.showBorder, isTrue);
+
+      final tagSize = tester.element(find.byType(GtAvatar)).dp(28.px);
+      expect(avatar.tagSize, tagSize);
+      expect(
+        tester.getSize(
+          find.descendant(
+            of: find.byType(GtAvatar),
+            matching: find.byType(GtSquareConstrainedBox),
+          ),
+        ),
+        Size.square(tagSize),
+      );
     });
 
     testWidgets('renders the steps in a compact status tracker', (
@@ -200,7 +212,7 @@ void main() {
       expect(find.text('TRX24072983910527NGN'), findsOneWidget);
     });
 
-    testWidgets('emphasises values and leads them with row images', (
+    testWidgets('emphasises values and leads them with closely spaced images', (
       tester,
     ) async {
       await tester.pumpWidget(buildTestWidget(buildBody()));
@@ -211,6 +223,21 @@ void main() {
       expect(category.highlightValue, isTrue);
       expect(category.valuePrefix, isNotNull);
       expect(category.valueSuffix, isNull);
+
+      final spacing = tester
+          .element(find.byType(GtTransferDetailBody))
+          .dp(2.px);
+      expect(category.valueSpacing, spacing);
+
+      final valueRow = tester
+          .widgetList<Row>(
+            find.descendant(
+              of: tileIn('transfer-detail-section-0-tile-0'),
+              matching: find.byType(Row),
+            ),
+          )
+          .firstWhere((row) => row.mainAxisAlignment == MainAxisAlignment.end);
+      expect(valueRow.spacing, spacing);
     });
 
     testWidgets('renders the actions and invokes them', (tester) async {
@@ -287,6 +314,7 @@ void main() {
       expect(tile.valueSuffix, isNotNull);
       expect(tile.valuePrefix, isNull);
       expect(tile.labelSuffix, isNull);
+      expect(tile.valueSpacing, isNull);
     });
 
     testWidgets('renders an info icon only when onInfoTap is supplied', (


### PR DESCRIPTION
## Description

- **Purpose:** Feature
- **Issue Link:** #206
- **Summary:** Adds the transfer detail screen from the Personal design file: `GtTransferDetailBody` and `GtTransferDetailScaffold`, built on the same foundations as `GtReceiptBody` / `GtReceiptScaffold`. To support it:
  - `GtStatusTracker` gains a `compact` variant.
  - `GtBalanceText` can hide its visibility icon.
  - The shared receipt parts get a few opt-in options: an info icon on a row, value emphasis, and image placement.

  Every new option defaults to the previous behaviour, so existing receipt, confirmation and dashboard screens render unchanged.

## ✨ Type of Change

- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance Improvement
- [x] 🎨 UI/UX Change (Screenshots Required)
- [x] 🛠️ Refactoring

**New components**
- `GtTransferDetailBody`: the full detail screen body. From top to bottom:
  - the recipient's avatar (with an optional bank tag) and name
  - the amount
  - a centred, wrapping row of actions
  - a compact status card
  - one untitled card per `GtTransferDetailSection`

  `amount` is a `num` rendered through `GtBalanceText` with the eye icon hidden.
- `GtTransferDetailScaffold`: the same layout as `GtReceiptScaffold` (optional download button, close button, floating "Report a problem" bar), typed to `GtTransferDetailBody`.
- `GtTransferDetailSection`: an untitled group of `GtReceiptTileData` rows. It's a separate model rather than a looser `GtConfirmationSection.title`, because `GtPdfReceiptSection.fromConfirmation` depends on that title.
- `GtStatusTrackerVariant` and `GtStatusTrackerCompactStep`: the dense timeline for the detail card. It has 12dp nodes, labels in their natural casing, trailing timestamps and no terminal checkmark.

**Changes to existing components (all opt-in)**
- `GtStatusTracker.variant`: `standard` (the default) or `compact`. Each layout is its own private widget behind a `switch`, and the standard one is the original build, unchanged.
  - **Compact connector rule:** the track turns green once every step before the last has succeeded **and** the last step is no longer pending. So "Processed ✓ → Sent ✓ → Reversed" is green, but "Processed ✓ → Failed → Reversed" stays grey. This comes from the nine tracker states in the design and deliberately differs from the standard all-steps-succeeded rule.
- `GtBalanceText.showVisibilityIcon` (default `true`): when `false`, the eye icon and its gap are removed and the line can't be tapped, so `onVisibilityIconTap` is ignored. `hidden` still masks the amount.
- `GtReceiptDetailTile.highlightValue` and `.imagePosition`: a soft label over a strong value, with the image before the value. The defaults keep receipt and confirmation rows as they were.
- `GtReceiptTileData.onInfoTap` and `.infoSemanticsLabel`: a tappable info icon after the label (the "Fees (VAT Incl) ⓘ" row). Tapping it doesn't trigger the row's `onTap`.
- `GtDoubleColumnListTile.labelSuffix`: a widget after the label. The label is truncated to make room.
- `GtReceiptActionButton`: `GtReceiptBody`'s private `_ReceiptAction`, now public and shared. It gains an `alignment` parameter (default `.center`; the detail body passes `null` inside its `Wrap`).

**Gallery**
- New **GtTransferDetailScaffold** and **GtTransferDetailBody** pages. A Scenario knob covers all eight transfer outcomes in the design.
- **GtStatusTracker** has a Variant knob.
- **Balance** (`GtBalanceText`) has a "Show visibility icon" knob.

**Breaking**
- None. `GtTransferDetailBody.amount` is a `num`, but the widget is new in this PR.

## 📸 Visuals (Screenshots or Screen Recordings)


https://github.com/user-attachments/assets/e1327a5b-bcd6-415c-b977-484a668904d8
<img width="434" height="958" alt="Screenshot 2026-09-10 at 21 17 33" src="https://github.com/user-attachments/assets/6feb73e1-d504-44d9-9941-b2fbeff7563a" />
<img width="434" height="958" alt="Screenshot 2026-09-10 at 21 17 40" src="https://github.com/user-attachments/assets/93771b72-cd6a-4313-94aa-d844e1c5d087" />


## 🧪 How Has This Been Tested?

- [ ] Unit Tests Added/Updated
- [x] Widget Tests Added/Updated
  - `test/gt_transfer_detail_test.dart` (new, 19 tests):
    - body: rendering, currency, avatar and tag, compact tracker, omitted status card, keyed sections, value emphasis, actions, the empty-section assert, amount semantics
    - tiles: default emphasis, the info icon, the info tap not firing the row tap, semantics labels
    - scaffold: close, report, download
  - `test/gt_status_tracker_test.dart`: a new compact-variant group (6 tests). It covers casing, timestamps, no terminal checkmark, no trailing connector, and the grey/green track rule for every final-step outcome.
  - `test/gt_balance_text_test.dart` (new, 4 tests):
    - the icon shows and is tappable by default
    - hiding the icon removes the tap target
    - masking still works without the icon
    - animation still works without the icon
- [ ] Manual Testing (Describe steps below)
  - *Steps:*
    1. `cd gallery && flutter run`
    2. Open **GtTransferDetailScaffold → Present Transfer Detail Modal**. Step the **Scenario** knob through all eight outcomes and compare the tracker dots, timestamps and track colour with the Figma frames.
    3. Tap the ⓘ next to "Fees (VAT Incl)" and "Stamp duty". A toast explains the fee, and the row itself doesn't fire.
    4. Tap Reference, Transaction ID and Session ID. Each copies its value.
    5. Toggle **Show Download Action**, and switch **Actions Preset** to check the action row centres and wraps.
    6. Open **GtStatusTracker** and set **Variant** to `compact`.
    7. Open **Balance** and turn off **Show visibility icon**. The eye disappears and tapping the line does nothing.

## 📋 Checklist

- [x] `flutter analyze` passes locally: clean in `lib/`, `test/` and `gallery/lib/`.
- [ ] `flutter test` passes (all tests green): **298 pass, 2 fail**, both in `test/gt_motion_test.dart`:
  - *GtBalanceText can animate visible amount changes*
  - *GtBalanceText keeps masked balances static*

  Both fail the same way on `main` (85f0d9c8). They are stale `"12.00 Naira"` expectations left by #207's `GtBalanceText` rework, already flagged in that PR, and aren't touched here. Gallery tests pass.
- [ ] `dart format` applied: one line in `lib/widgets/molecules/tiles/gt_info_tiles.dart` (the new `labelSuffix` row) still needs formatting. The rest of the diff is formatted.
- [x] No unused code.
- [ ] Verified UI on small/large screens: not yet. Only widget tests have run; nothing has been rendered against the Figma frames.